### PR TITLE
add nut models to class library

### DIFF
--- a/ClassLibrary/Data/AppDbContext.cs
+++ b/ClassLibrary/Data/AppDbContext.cs
@@ -6,5 +6,33 @@ namespace ClassLibrary.Data;
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     public DbSet<User> Users { get; set; } = default!;
+
+    public DbSet<NutUser> NutUsers { get; set; } = default!;
+
+    public DbSet<UserData> UserData { get; set; } = default!;
+
+    public DbSet<Meal> Meals { get; set; } = default!;
+
+    public DbSet<MealPlan> MealPlans { get; set; } = default!;
+
+    public DbSet<Ingredient> Ingredients { get; set; } = default!;
+
+    public DbSet<Inventory> Inventories { get; set; } = default!;
+
+    public DbSet<ShoppingItem> ShoppingItems { get; set; } = default!;
+
+    public DbSet<Reminder> Reminders { get; set; } = default!;
+
+    public DbSet<DailyLog> DailyLogs { get; set; } = default!;
+
+    public DbSet<Conversation> Conversations { get; set; } = default!;
+
+    public DbSet<Message> Messages { get; set; } = default!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Ingredient>()
+            .HasKey(i => i.FoodId);
+    }
 }
 

--- a/ClassLibrary/Extensions/DatabaseInitializer.cs
+++ b/ClassLibrary/Extensions/DatabaseInitializer.cs
@@ -26,6 +26,23 @@ public static class DatabaseInitializer
                 Email = SEED_USER_EMAIL,
                 FullName = SEED_USER_FULL_NAME
             });
+
+        dbContext.NutUsers.AddRange(
+            new NutUser { Username = "nutritionist1", Password = "password123", Role = "Nutritionist" },
+            new NutUser { Username = "testuser", Password = "password123", Role = "User" });
+
+        dbContext.Ingredients.AddRange(
+            new Ingredient { FoodId = 1, Name = "Chicken Breast", CaloriesPer100g = 165, ProteinPer100g = 31, CarbsPer100g = 0, FatPer100g = 3.6 },
+            new Ingredient { FoodId = 2, Name = "Brown Rice", CaloriesPer100g = 111, ProteinPer100g = 2.6, CarbsPer100g = 23, FatPer100g = 0.9 },
+            new Ingredient { FoodId = 3, Name = "Broccoli", CaloriesPer100g = 34, ProteinPer100g = 2.8, CarbsPer100g = 7, FatPer100g = 0.4 },
+            new Ingredient { FoodId = 4, Name = "Salmon", CaloriesPer100g = 208, ProteinPer100g = 20, CarbsPer100g = 0, FatPer100g = 13 },
+            new Ingredient { FoodId = 5, Name = "Oats", CaloriesPer100g = 389, ProteinPer100g = 16.9, CarbsPer100g = 66.3, FatPer100g = 6.9 });
+
+        dbContext.Meals.AddRange(
+            new Meal { Name = "Grilled Chicken with Rice", Calories = 450, Carbs = 40, Fat = 10, Protein = 45, Description = "Healthy grilled chicken served with steamed brown rice" },
+            new Meal { Name = "Salmon Bowl", Calories = 520, Carbs = 35, Fat = 22, Protein = 38, Description = "Fresh salmon with quinoa and roasted vegetables", IsKeto = true, IsGlutenFree = true },
+            new Meal { Name = "Oatmeal Breakfast", Calories = 350, Carbs = 55, Fat = 8, Protein = 15, Description = "Hearty oats with berries and honey", IsVegan = true, IsLactoseFree = true });
+
         dbContext.SaveChanges();
     }
 }

--- a/ClassLibrary/Models/Conversation.cs
+++ b/ClassLibrary/Models/Conversation.cs
@@ -1,0 +1,12 @@
+namespace ClassLibrary.Models;
+
+public sealed class Conversation
+{
+    public int Id { get; set; }
+
+    public bool HasUnanswered { get; set; }
+
+    public int UserId { get; set; }
+
+    public string Username { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/DailyLog.cs
+++ b/ClassLibrary/Models/DailyLog.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ClassLibrary.Models;
+
+public sealed class DailyLog
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public int MealId { get; set; }
+
+    public DateTime LoggedAt { get; set; }
+
+    public double Calories { get; set; }
+
+    public double Protein { get; set; }
+
+    public double Carbs { get; set; }
+
+    public double Fats { get; set; }
+}

--- a/ClassLibrary/Models/Ingredient.cs
+++ b/ClassLibrary/Models/Ingredient.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class Ingredient
+{
+    [Key]
+    public int FoodId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public double CaloriesPer100g { get; set; }
+
+    public double ProteinPer100g { get; set; }
+
+    public double CarbsPer100g { get; set; }
+
+    public double FatPer100g { get; set; }
+}

--- a/ClassLibrary/Models/Inventory.cs
+++ b/ClassLibrary/Models/Inventory.cs
@@ -1,0 +1,14 @@
+namespace ClassLibrary.Models;
+
+public sealed class Inventory
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public int IngredientId { get; set; }
+
+    public int QuantityGrams { get; set; }
+
+    public string IngredientName { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/Meal.cs
+++ b/ClassLibrary/Models/Meal.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class Meal
+{
+    [Key]
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int Calories { get; set; }
+
+    public int Carbs { get; set; }
+
+    public int Fat { get; set; }
+
+    public int Protein { get; set; }
+
+    public bool IsVegan { get; set; }
+
+    public bool IsKeto { get; set; }
+
+    public bool IsGlutenFree { get; set; }
+
+    public bool IsLactoseFree { get; set; }
+
+    public bool IsNutFree { get; set; }
+
+    public bool IsFavorite { get; set; }
+
+    public string Description { get; set; } = string.Empty;
+
+    public string ImageUrl { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/MealFilter.cs
+++ b/ClassLibrary/Models/MealFilter.cs
@@ -1,0 +1,18 @@
+namespace ClassLibrary.Models;
+
+public sealed class MealFilter
+{
+    public bool IsKeto { get; set; }
+
+    public bool IsVegan { get; set; }
+
+    public bool IsNutFree { get; set; }
+
+    public bool IsLactoseFree { get; set; }
+
+    public bool IsGlutenFree { get; set; }
+
+    public bool IsFavoriteOnly { get; set; }
+
+    public string SearchTerm { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/MealPlan.cs
+++ b/ClassLibrary/Models/MealPlan.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ClassLibrary.Models;
+
+public sealed class MealPlan
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public string GoalType { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/Message.cs
+++ b/ClassLibrary/Models/Message.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ClassLibrary.Models;
+
+public sealed class Message
+{
+    public int Id { get; set; }
+
+    public DateTime SentAt { get; set; }
+
+    public int ConversationId { get; set; }
+
+    public int SenderId { get; set; }
+
+    public string SenderUsername { get; set; } = string.Empty;
+
+    public string SenderRole { get; set; } = string.Empty;
+
+    public string TextContent { get; set; } = string.Empty;
+
+    [NotMapped]
+    public bool IsFromCurrentUser { get; set; }
+
+    [NotMapped]
+    public string SentAtFormatted => SentAt.ToString("g");
+}

--- a/ClassLibrary/Models/NutUser.cs
+++ b/ClassLibrary/Models/NutUser.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class NutUser
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required(ErrorMessage = "Username is mandatory")]
+    [StringLength(30, MinimumLength = 3)]
+    [RegularExpression(@"^[a-zA-Z0-9]+$", ErrorMessage = "Username must be alphanumeric")]
+    public string Username { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Password is mandatory")]
+    [StringLength(30, MinimumLength = 8)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Role is mandatory")]
+    [RegularExpression(@"^(User|Nutritionist)$", ErrorMessage = "Role must be 'User' or 'Nutritionist'")]
+    public string Role { get; set; } = "User";
+}

--- a/ClassLibrary/Models/Reminder.cs
+++ b/ClassLibrary/Models/Reminder.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ClassLibrary.Models;
+
+public sealed class Reminder
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public int UserId { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public bool HasSound { get; set; }
+
+    [Required]
+    public TimeSpan Time { get; set; }
+
+    public string ReminderDate { get; set; } = string.Empty;
+
+    public string Frequency { get; set; } = "Once";
+
+    [NotMapped]
+    public string FullDateTimeDisplay => $"{ReminderDate ?? "No date"} at {Time}";
+}

--- a/ClassLibrary/Models/ShoppingItem.cs
+++ b/ClassLibrary/Models/ShoppingItem.cs
@@ -1,0 +1,16 @@
+namespace ClassLibrary.Models;
+
+public sealed class ShoppingItem
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public int IngredientId { get; set; }
+
+    public string IngredientName { get; set; } = string.Empty;
+
+    public double QuantityGrams { get; set; }
+
+    public bool IsChecked { get; set; }
+}

--- a/ClassLibrary/Models/UserData.cs
+++ b/ClassLibrary/Models/UserData.cs
@@ -1,0 +1,199 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class UserData
+{
+    private const int MinWeightKg = 1;
+    private const int MaxWeightKg = 500;
+    private const int MinHeightCm = 1;
+    private const int MaxHeightCm = 300;
+    private const string ErrorWeightRange = "Weight must be a positive whole number, between 1 and 500";
+    private const string ErrorHeightRange = "Height must be a positive whole number, between 1 and 300";
+    private const string ErrorGenderRequired = "Please select a gender";
+    private const string ErrorGoalRequired = "Please select a goal";
+    private const string ErrorGenderInvalid = "Gender must be 'male' or 'female'";
+    private const string ErrorGoalInvalid = "Select a valid goal";
+    private const string GenderMale = "male";
+    private const string GenderFemale = "female";
+    private const string GoalBulk = "bulk";
+    private const string GoalCut = "cut";
+    private const string GoalMaintenance = "maintenance";
+    private const string GoalWellBeing = "well-being";
+    private const string RegexGender = @"^(male|female)$";
+    private const string RegexGoal = @"^(bulk|cut|maintenance|well-being)$";
+    private const double BmrWeightFactor = 10.0;
+    private const double BmrHeightFactor = 6.25;
+    private const double BmrAgeFactor = 5.0;
+    private const double BmrMaleOffset = 5.0;
+    private const double BmrFemaleOffset = 161.0;
+    private const double ActivityMultiplier = 1.55;
+    private const int BulkCalorieDelta = 300;
+    private const int CutCalorieDelta = -300;
+    private const double ProteinBulk = 2.0;
+    private const double ProteinCut = 2.2;
+    private const double ProteinMaintenance = 1.8;
+    private const double ProteinWellBeing = 1.6;
+    private const double FatBulkCut = 0.25;
+    private const double FatMaintenance = 0.28;
+    private const double FatWellBeing = 0.30;
+    private const int CaloriesPerGramProtein = 4;
+    private const int CaloriesPerGramCarbs = 4;
+    private const int CaloriesPerGramFat = 9;
+
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    [Range(MinWeightKg, MaxWeightKg, ErrorMessage = "Weight must be a positive whole number, between 1 and 500")]
+    public int Weight { get; set; }
+
+    [Range(MinHeightCm, MaxHeightCm, ErrorMessage = "Height must be a positive whole number, between 1 and 300")]
+    public int Height { get; set; }
+
+    public int Age { get; set; }
+
+    [Required(ErrorMessage = "Please select a gender")]
+    [RegularExpression(@"^(male|female)$", ErrorMessage = "Gender must be 'male' or 'female'")]
+    public string Gender { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Please select a goal")]
+    [RegularExpression(@"^(bulk|cut|maintenance|well-being)$", ErrorMessage = "Select a valid goal")]
+    public string Goal { get; set; } = string.Empty;
+
+    public double Bmi { get; set; }
+
+    public int CalorieNeeds { get; set; }
+
+    public int ProteinNeeds { get; set; }
+
+    public int CarbNeeds { get; set; }
+
+    public int FatNeeds { get; set; }
+
+    public int CalculateAge(DateTimeOffset? birthDate)
+    {
+        if (birthDate == null)
+        {
+            return 0;
+        }
+
+        var today = DateTime.Today;
+        var birth = birthDate.Value.DateTime;
+
+        int age = today.Year - birth.Year;
+        if (birth.Date > today.AddYears(-age))
+        {
+            age--;
+        }
+
+        return age;
+    }
+
+    public double CalculateBmi()
+    {
+        if (Height <= 0 || Weight <= 0)
+        {
+            return 0;
+        }
+
+        double heightMeters = Height / 100.0;
+        double bmi = Weight / (heightMeters * heightMeters);
+
+        return (int)Math.Round(bmi);
+    }
+
+    public int CalculateCalorieNeeds()
+    {
+        if (Weight <= 0 || Height <= 0 || Age <= 0)
+        {
+            return 0;
+        }
+
+        double bmr =
+            Gender.Equals(GenderMale, StringComparison.OrdinalIgnoreCase)
+                ? (BmrWeightFactor * Weight) +
+                  (BmrHeightFactor * Height) -
+                  (BmrAgeFactor * Age) +
+                  BmrMaleOffset
+                : Gender.Equals(GenderFemale, StringComparison.OrdinalIgnoreCase)
+                    ? (BmrWeightFactor * Weight) +
+                      (BmrHeightFactor * Height) -
+                      (BmrAgeFactor * Age) -
+                      BmrFemaleOffset
+                    : 0;
+
+        if (bmr <= 0)
+        {
+            return 0;
+        }
+
+        double tdee = bmr * ActivityMultiplier;
+
+        double adjustedCalories = Goal.ToLower() switch
+        {
+            GoalBulk => tdee + BulkCalorieDelta,
+            GoalCut => tdee + CutCalorieDelta,
+            GoalMaintenance => tdee,
+            GoalWellBeing => tdee,
+            _ => tdee
+        };
+
+        return (int)Math.Round(adjustedCalories);
+    }
+
+    public int CalculateProteinNeeds()
+    {
+        if (Weight <= 0)
+        {
+            return 0;
+        }
+
+        double proteinPerKg = Goal.ToLower() switch
+        {
+            GoalBulk => ProteinBulk,
+            GoalCut => ProteinCut,
+            GoalMaintenance => ProteinMaintenance,
+            GoalWellBeing => ProteinWellBeing,
+            _ => ProteinMaintenance
+        };
+
+        return (int)Math.Round(Weight * proteinPerKg);
+    }
+
+    public int CalculateFatNeeds()
+    {
+        int calories = CalculateCalorieNeeds();
+        if (calories <= 0)
+        {
+            return 0;
+        }
+
+        double fatRatio = Goal.ToLower() switch
+        {
+            GoalBulk or GoalCut => FatBulkCut,
+            GoalMaintenance => FatMaintenance,
+            GoalWellBeing => FatWellBeing,
+            _ => FatBulkCut
+        };
+
+        double fatCalories = calories * fatRatio;
+        return (int)Math.Round(fatCalories / CaloriesPerGramFat);
+    }
+
+    public int CalculateCarbNeeds()
+    {
+        int calories = CalculateCalorieNeeds();
+        int proteinCalories = CalculateProteinNeeds() * CaloriesPerGramProtein;
+        int fatCalories = CalculateFatNeeds() * CaloriesPerGramFat;
+
+        if (calories <= 0)
+        {
+            return 0;
+        }
+
+        int carbCalories = Math.Max(0, calories - proteinCalories - fatCalories);
+        return (int)Math.Round(carbCalories / (double)CaloriesPerGramCarbs);
+    }
+}

--- a/ClassLibrary/Models/UserSession.cs
+++ b/ClassLibrary/Models/UserSession.cs
@@ -1,0 +1,24 @@
+namespace ClassLibrary.Models;
+
+public static class UserSession
+{
+    public static string? Username { get; private set; }
+
+    public static string? Role { get; private set; }
+
+    public static int? UserId { get; private set; }
+
+    public static void Login(int userId, string username, string role)
+    {
+        UserId = userId;
+        Username = username;
+        Role = role;
+    }
+
+    public static void Logout()
+    {
+        UserId = null;
+        Username = null;
+        Role = null;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds all 13 NUT domain models adapted for EF Core (ClassLibrary/Models/)
- Strips CommunityToolkit.Mvvm (ObservableObject, ObservableValidator, [ObservableProperty])
- Converts WinUI-specific properties (Visibility) to plain POCOs
- Marks computed properties (FullDateTimeDisplay, SentAtFormatted, IsFromCurrentUser) as [NotMapped]
- Configures Ingredient.FoodId as non-convention primary key via Fluent API
- Registers all entities in AppDbContext with seed data
- Renames NUT User to NutUser to avoid conflict with existing User model

## Issues Closed
Closes #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34
