### PR TITLE
add nut repository layer

### DIFF
--- a/ClassLibrary/DTOs/IngredientViewModel.cs
+++ b/ClassLibrary/DTOs/IngredientViewModel.cs
@@ -1,0 +1,18 @@
+namespace ClassLibrary.DTOs;
+
+public sealed class IngredientViewModel
+{
+    public int IngredientId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public double Quantity { get; set; }
+
+    public double Calories { get; set; }
+
+    public double Protein { get; set; }
+
+    public double Carbs { get; set; }
+
+    public double Fat { get; set; }
+}

--- a/ClassLibrary/Data/AppDbContext.cs
+++ b/ClassLibrary/Data/AppDbContext.cs
@@ -29,10 +29,25 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 
     public DbSet<Message> Messages { get; set; } = default!;
 
+    public DbSet<Favorite> Favorites { get; set; } = default!;
+
+    public DbSet<MealsIngredient> MealsIngredients { get; set; } = default!;
+
+    public DbSet<MealPlanMeal> MealPlanMeals { get; set; } = default!;
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<Ingredient>()
             .HasKey(i => i.FoodId);
+
+        modelBuilder.Entity<Favorite>()
+            .HasKey(f => new { f.UserId, f.MealId });
+
+        modelBuilder.Entity<MealsIngredient>()
+            .HasKey(mi => new { mi.MealId, mi.FoodId });
+
+        modelBuilder.Entity<MealPlanMeal>()
+            .HasKey(mpm => new { mpm.MealPlanId, mpm.MealId });
     }
 }
 

--- a/ClassLibrary/Data/AppDbContext.cs
+++ b/ClassLibrary/Data/AppDbContext.cs
@@ -6,5 +6,33 @@ namespace ClassLibrary.Data;
 public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     public DbSet<User> Users { get; set; } = default!;
+
+    public DbSet<NutUser> NutUsers { get; set; } = default!;
+
+    public DbSet<UserData> UserData { get; set; } = default!;
+
+    public DbSet<Meal> Meals { get; set; } = default!;
+
+    public DbSet<MealPlan> MealPlans { get; set; } = default!;
+
+    public DbSet<Ingredient> Ingredients { get; set; } = default!;
+
+    public DbSet<Inventory> Inventories { get; set; } = default!;
+
+    public DbSet<ShoppingItem> ShoppingItems { get; set; } = default!;
+
+    public DbSet<Reminder> Reminders { get; set; } = default!;
+
+    public DbSet<DailyLog> DailyLogs { get; set; } = default!;
+
+    public DbSet<Conversation> Conversations { get; set; } = default!;
+
+    public DbSet<Message> Messages { get; set; } = default!;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Ingredient>()
+            .HasKey(i => i.FoodId);
+    }
 }
 

--- a/ClassLibrary/Extensions/DatabaseInitializer.cs
+++ b/ClassLibrary/Extensions/DatabaseInitializer.cs
@@ -26,6 +26,23 @@ public static class DatabaseInitializer
                 Email = SEED_USER_EMAIL,
                 FullName = SEED_USER_FULL_NAME
             });
+
+        dbContext.NutUsers.AddRange(
+            new NutUser { Username = "nutritionist1", Password = "password123", Role = "Nutritionist" },
+            new NutUser { Username = "testuser", Password = "password123", Role = "User" });
+
+        dbContext.Ingredients.AddRange(
+            new Ingredient { FoodId = 1, Name = "Chicken Breast", CaloriesPer100g = 165, ProteinPer100g = 31, CarbsPer100g = 0, FatPer100g = 3.6 },
+            new Ingredient { FoodId = 2, Name = "Brown Rice", CaloriesPer100g = 111, ProteinPer100g = 2.6, CarbsPer100g = 23, FatPer100g = 0.9 },
+            new Ingredient { FoodId = 3, Name = "Broccoli", CaloriesPer100g = 34, ProteinPer100g = 2.8, CarbsPer100g = 7, FatPer100g = 0.4 },
+            new Ingredient { FoodId = 4, Name = "Salmon", CaloriesPer100g = 208, ProteinPer100g = 20, CarbsPer100g = 0, FatPer100g = 13 },
+            new Ingredient { FoodId = 5, Name = "Oats", CaloriesPer100g = 389, ProteinPer100g = 16.9, CarbsPer100g = 66.3, FatPer100g = 6.9 });
+
+        dbContext.Meals.AddRange(
+            new Meal { Name = "Grilled Chicken with Rice", Calories = 450, Carbs = 40, Fat = 10, Protein = 45, Description = "Healthy grilled chicken served with steamed brown rice" },
+            new Meal { Name = "Salmon Bowl", Calories = 520, Carbs = 35, Fat = 22, Protein = 38, Description = "Fresh salmon with quinoa and roasted vegetables", IsKeto = true, IsGlutenFree = true },
+            new Meal { Name = "Oatmeal Breakfast", Calories = 350, Carbs = 55, Fat = 8, Protein = 15, Description = "Hearty oats with berries and honey", IsVegan = true, IsLactoseFree = true });
+
         dbContext.SaveChanges();
     }
 }

--- a/ClassLibrary/Extensions/ServiceCollectionExtensions.cs
+++ b/ClassLibrary/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,16 @@ public static class ServiceCollectionExtensions
             options.UseInMemoryDatabase(IN_MEMORY_DATABASE_NAME));
         services.AddScoped<IUserRepository, UserRepository>();
 
+        services.AddScoped<INutUserRepository, NutUserRepository>();
+        services.AddScoped<IMealRepository, MealRepository>();
+        services.AddScoped<IMealPlanRepository, MealPlanRepository>();
+        services.AddScoped<IIngredientRepository, IngredientRepository>();
+        services.AddScoped<IInventoryRepository, InventoryRepository>();
+        services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
+        services.AddScoped<IReminderRepository, ReminderRepository>();
+        services.AddScoped<IDailyLogRepository, DailyLogRepository>();
+        services.AddScoped<IChatRepository, ChatRepository>();
+
         return services;
     }
 }

--- a/ClassLibrary/IRepositories/IChatRepository.cs
+++ b/ClassLibrary/IRepositories/IChatRepository.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IChatRepository
+{
+    Task AddMessageAsync(int conversationId, int senderId, string text, bool isNutritionist, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Conversation>> GetAllConversationsAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Conversation>> GetConversationsWhereNutritionistRespondedAsync(int nutritionistId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Conversation>> GetConversationsWithMessagesAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Conversation>> GetConversationsWithUserMessagesAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Message>> GetMessagesForConversationAsync(int conversationId, CancellationToken cancellationToken = default);
+
+    Task<Conversation> GetOrCreateConversationForUserAsync(int userId, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IDailyLogRepository.cs
+++ b/ClassLibrary/IRepositories/IDailyLogRepository.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IDailyLogRepository
+{
+    Task AddAsync(DailyLog log, CancellationToken cancellationToken = default);
+
+    Task<DailyLog> GetNutritionTotalsForRangeAsync(int userId, DateTime startInclusive, DateTime endExclusive, CancellationToken cancellationToken = default);
+
+    Task<bool> HasAnyLogsAsync(int userId, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IIngredientRepository.cs
+++ b/ClassLibrary/IRepositories/IIngredientRepository.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IIngredientRepository
+{
+    Task<IReadOnlyList<Ingredient>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<int> GetOrCreateIngredientIdAsync(string name, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<KeyValuePair<int, string>>> SearchIngredientsAsync(string search, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IInventoryRepository.cs
+++ b/ClassLibrary/IRepositories/IInventoryRepository.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IInventoryRepository
+{
+    Task AddAsync(Inventory entity, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Inventory>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task<Inventory?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Inventory entity, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IMealPlanRepository.cs
+++ b/ClassLibrary/IRepositories/IMealPlanRepository.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.DTOs;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IMealPlanRepository
+{
+    Task AddAsync(MealPlan entity, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<int> GeneratePersonalizedDailyMealPlanAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MealPlan>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<MealPlan?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<IngredientViewModel>> GetIngredientsForMealAsync(int mealId, CancellationToken cancellationToken = default);
+
+    Task<MealPlan?> GetLatestMealPlanAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Meal>> GetMealsForMealPlanAsync(int mealPlanId, CancellationToken cancellationToken = default);
+
+    Task<MealPlan?> GetTodaysMealPlanAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task SaveMealsToDailyLogAsync(int userId, IReadOnlyList<Meal> meals, CancellationToken cancellationToken = default);
+
+    Task SaveMealToDailyLogAsync(int userId, int mealId, int calories, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(MealPlan entity, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IMealRepository.cs
+++ b/ClassLibrary/IRepositories/IMealRepository.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IMealRepository
+{
+    Task AddAsync(Meal entity, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Meal>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<Meal?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Meal>> GetFilteredMealsAsync(MealFilter filter, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetIngredientLinesForMealAsync(int mealId, CancellationToken cancellationToken = default);
+
+    Task SetFavoriteAsync(int userId, int mealId, bool isFavorite, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Meal entity, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/INutUserRepository.cs
+++ b/ClassLibrary/IRepositories/INutUserRepository.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface INutUserRepository
+{
+    Task AddAsync(NutUser entity, CancellationToken cancellationToken = default);
+
+    Task AddUserDataAsync(UserData data, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<NutUser>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<NutUser?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<NutUser?> GetByUsernameAndPasswordAsync(string username, string password, CancellationToken cancellationToken = default);
+
+    Task<UserData?> GetUserDataByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(NutUser entity, CancellationToken cancellationToken = default);
+
+    Task UpdateUserDataAsync(UserData data, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IReminderRepository.cs
+++ b/ClassLibrary/IRepositories/IReminderRepository.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IReminderRepository
+{
+    Task AddAsync(Reminder entity, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Reminder>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<Reminder>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task<Reminder?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<Reminder?> GetNextReminderAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Reminder entity, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IRepository.cs
+++ b/ClassLibrary/IRepositories/IRepository.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IRepository<T>
+    where T : class
+{
+    Task<T?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<T>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task AddAsync(T entity, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(T entity, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IShoppingListRepository.cs
+++ b/ClassLibrary/IRepositories/IShoppingListRepository.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IShoppingListRepository
+{
+    Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task<ShoppingItem?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<ShoppingItem>> GetIngredientsNeededFromMealPlanAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/Models/Conversation.cs
+++ b/ClassLibrary/Models/Conversation.cs
@@ -1,0 +1,12 @@
+namespace ClassLibrary.Models;
+
+public sealed class Conversation
+{
+    public int Id { get; set; }
+
+    public bool HasUnanswered { get; set; }
+
+    public int UserId { get; set; }
+
+    public string Username { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/DailyLog.cs
+++ b/ClassLibrary/Models/DailyLog.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace ClassLibrary.Models;
+
+public sealed class DailyLog
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public int MealId { get; set; }
+
+    public DateTime LoggedAt { get; set; }
+
+    public double Calories { get; set; }
+
+    public double Protein { get; set; }
+
+    public double Carbs { get; set; }
+
+    public double Fats { get; set; }
+}

--- a/ClassLibrary/Models/Favorite.cs
+++ b/ClassLibrary/Models/Favorite.cs
@@ -1,0 +1,8 @@
+namespace ClassLibrary.Models;
+
+public sealed class Favorite
+{
+    public int UserId { get; set; }
+
+    public int MealId { get; set; }
+}

--- a/ClassLibrary/Models/Ingredient.cs
+++ b/ClassLibrary/Models/Ingredient.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class Ingredient
+{
+    [Key]
+    public int FoodId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public double CaloriesPer100g { get; set; }
+
+    public double ProteinPer100g { get; set; }
+
+    public double CarbsPer100g { get; set; }
+
+    public double FatPer100g { get; set; }
+}

--- a/ClassLibrary/Models/Inventory.cs
+++ b/ClassLibrary/Models/Inventory.cs
@@ -1,0 +1,14 @@
+namespace ClassLibrary.Models;
+
+public sealed class Inventory
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public int IngredientId { get; set; }
+
+    public int QuantityGrams { get; set; }
+
+    public string IngredientName { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/Meal.cs
+++ b/ClassLibrary/Models/Meal.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class Meal
+{
+    [Key]
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int Calories { get; set; }
+
+    public int Carbs { get; set; }
+
+    public int Fat { get; set; }
+
+    public int Protein { get; set; }
+
+    public bool IsVegan { get; set; }
+
+    public bool IsKeto { get; set; }
+
+    public bool IsGlutenFree { get; set; }
+
+    public bool IsLactoseFree { get; set; }
+
+    public bool IsNutFree { get; set; }
+
+    public bool IsFavorite { get; set; }
+
+    public string Description { get; set; } = string.Empty;
+
+    public string ImageUrl { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/MealFilter.cs
+++ b/ClassLibrary/Models/MealFilter.cs
@@ -1,0 +1,18 @@
+namespace ClassLibrary.Models;
+
+public sealed class MealFilter
+{
+    public bool IsKeto { get; set; }
+
+    public bool IsVegan { get; set; }
+
+    public bool IsNutFree { get; set; }
+
+    public bool IsLactoseFree { get; set; }
+
+    public bool IsGlutenFree { get; set; }
+
+    public bool IsFavoriteOnly { get; set; }
+
+    public string SearchTerm { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/MealPlan.cs
+++ b/ClassLibrary/Models/MealPlan.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ClassLibrary.Models;
+
+public sealed class MealPlan
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public string GoalType { get; set; } = string.Empty;
+}

--- a/ClassLibrary/Models/MealPlanMeal.cs
+++ b/ClassLibrary/Models/MealPlanMeal.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace ClassLibrary.Models;
+
+public sealed class MealPlanMeal
+{
+    public int MealPlanId { get; set; }
+
+    public int MealId { get; set; }
+
+    public string MealType { get; set; } = string.Empty;
+
+    public DateTime AssignedAt { get; set; }
+
+    public bool IsConsumed { get; set; }
+}

--- a/ClassLibrary/Models/MealsIngredient.cs
+++ b/ClassLibrary/Models/MealsIngredient.cs
@@ -1,0 +1,10 @@
+namespace ClassLibrary.Models;
+
+public sealed class MealsIngredient
+{
+    public int MealId { get; set; }
+
+    public int FoodId { get; set; }
+
+    public double Quantity { get; set; }
+}

--- a/ClassLibrary/Models/Message.cs
+++ b/ClassLibrary/Models/Message.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ClassLibrary.Models;
+
+public sealed class Message
+{
+    public int Id { get; set; }
+
+    public DateTime SentAt { get; set; }
+
+    public int ConversationId { get; set; }
+
+    public int SenderId { get; set; }
+
+    public string SenderUsername { get; set; } = string.Empty;
+
+    public string SenderRole { get; set; } = string.Empty;
+
+    public string TextContent { get; set; } = string.Empty;
+
+    [NotMapped]
+    public bool IsFromCurrentUser { get; set; }
+
+    [NotMapped]
+    public string SentAtFormatted => SentAt.ToString("g");
+}

--- a/ClassLibrary/Models/NutUser.cs
+++ b/ClassLibrary/Models/NutUser.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class NutUser
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required(ErrorMessage = "Username is mandatory")]
+    [StringLength(30, MinimumLength = 3)]
+    [RegularExpression(@"^[a-zA-Z0-9]+$", ErrorMessage = "Username must be alphanumeric")]
+    public string Username { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Password is mandatory")]
+    [StringLength(30, MinimumLength = 8)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Role is mandatory")]
+    [RegularExpression(@"^(User|Nutritionist)$", ErrorMessage = "Role must be 'User' or 'Nutritionist'")]
+    public string Role { get; set; } = "User";
+}

--- a/ClassLibrary/Models/Reminder.cs
+++ b/ClassLibrary/Models/Reminder.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ClassLibrary.Models;
+
+public sealed class Reminder
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public int UserId { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public bool HasSound { get; set; }
+
+    [Required]
+    public TimeSpan Time { get; set; }
+
+    public string ReminderDate { get; set; } = string.Empty;
+
+    public string Frequency { get; set; } = "Once";
+
+    [NotMapped]
+    public string FullDateTimeDisplay => $"{ReminderDate ?? "No date"} at {Time}";
+}

--- a/ClassLibrary/Models/ShoppingItem.cs
+++ b/ClassLibrary/Models/ShoppingItem.cs
@@ -1,0 +1,16 @@
+namespace ClassLibrary.Models;
+
+public sealed class ShoppingItem
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public int IngredientId { get; set; }
+
+    public string IngredientName { get; set; } = string.Empty;
+
+    public double QuantityGrams { get; set; }
+
+    public bool IsChecked { get; set; }
+}

--- a/ClassLibrary/Models/UserData.cs
+++ b/ClassLibrary/Models/UserData.cs
@@ -1,0 +1,199 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models;
+
+public sealed class UserData
+{
+    private const int MinWeightKg = 1;
+    private const int MaxWeightKg = 500;
+    private const int MinHeightCm = 1;
+    private const int MaxHeightCm = 300;
+    private const string ErrorWeightRange = "Weight must be a positive whole number, between 1 and 500";
+    private const string ErrorHeightRange = "Height must be a positive whole number, between 1 and 300";
+    private const string ErrorGenderRequired = "Please select a gender";
+    private const string ErrorGoalRequired = "Please select a goal";
+    private const string ErrorGenderInvalid = "Gender must be 'male' or 'female'";
+    private const string ErrorGoalInvalid = "Select a valid goal";
+    private const string GenderMale = "male";
+    private const string GenderFemale = "female";
+    private const string GoalBulk = "bulk";
+    private const string GoalCut = "cut";
+    private const string GoalMaintenance = "maintenance";
+    private const string GoalWellBeing = "well-being";
+    private const string RegexGender = @"^(male|female)$";
+    private const string RegexGoal = @"^(bulk|cut|maintenance|well-being)$";
+    private const double BmrWeightFactor = 10.0;
+    private const double BmrHeightFactor = 6.25;
+    private const double BmrAgeFactor = 5.0;
+    private const double BmrMaleOffset = 5.0;
+    private const double BmrFemaleOffset = 161.0;
+    private const double ActivityMultiplier = 1.55;
+    private const int BulkCalorieDelta = 300;
+    private const int CutCalorieDelta = -300;
+    private const double ProteinBulk = 2.0;
+    private const double ProteinCut = 2.2;
+    private const double ProteinMaintenance = 1.8;
+    private const double ProteinWellBeing = 1.6;
+    private const double FatBulkCut = 0.25;
+    private const double FatMaintenance = 0.28;
+    private const double FatWellBeing = 0.30;
+    private const int CaloriesPerGramProtein = 4;
+    private const int CaloriesPerGramCarbs = 4;
+    private const int CaloriesPerGramFat = 9;
+
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    [Range(MinWeightKg, MaxWeightKg, ErrorMessage = "Weight must be a positive whole number, between 1 and 500")]
+    public int Weight { get; set; }
+
+    [Range(MinHeightCm, MaxHeightCm, ErrorMessage = "Height must be a positive whole number, between 1 and 300")]
+    public int Height { get; set; }
+
+    public int Age { get; set; }
+
+    [Required(ErrorMessage = "Please select a gender")]
+    [RegularExpression(@"^(male|female)$", ErrorMessage = "Gender must be 'male' or 'female'")]
+    public string Gender { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Please select a goal")]
+    [RegularExpression(@"^(bulk|cut|maintenance|well-being)$", ErrorMessage = "Select a valid goal")]
+    public string Goal { get; set; } = string.Empty;
+
+    public double Bmi { get; set; }
+
+    public int CalorieNeeds { get; set; }
+
+    public int ProteinNeeds { get; set; }
+
+    public int CarbNeeds { get; set; }
+
+    public int FatNeeds { get; set; }
+
+    public int CalculateAge(DateTimeOffset? birthDate)
+    {
+        if (birthDate == null)
+        {
+            return 0;
+        }
+
+        var today = DateTime.Today;
+        var birth = birthDate.Value.DateTime;
+
+        int age = today.Year - birth.Year;
+        if (birth.Date > today.AddYears(-age))
+        {
+            age--;
+        }
+
+        return age;
+    }
+
+    public double CalculateBmi()
+    {
+        if (Height <= 0 || Weight <= 0)
+        {
+            return 0;
+        }
+
+        double heightMeters = Height / 100.0;
+        double bmi = Weight / (heightMeters * heightMeters);
+
+        return (int)Math.Round(bmi);
+    }
+
+    public int CalculateCalorieNeeds()
+    {
+        if (Weight <= 0 || Height <= 0 || Age <= 0)
+        {
+            return 0;
+        }
+
+        double bmr =
+            Gender.Equals(GenderMale, StringComparison.OrdinalIgnoreCase)
+                ? (BmrWeightFactor * Weight) +
+                  (BmrHeightFactor * Height) -
+                  (BmrAgeFactor * Age) +
+                  BmrMaleOffset
+                : Gender.Equals(GenderFemale, StringComparison.OrdinalIgnoreCase)
+                    ? (BmrWeightFactor * Weight) +
+                      (BmrHeightFactor * Height) -
+                      (BmrAgeFactor * Age) -
+                      BmrFemaleOffset
+                    : 0;
+
+        if (bmr <= 0)
+        {
+            return 0;
+        }
+
+        double tdee = bmr * ActivityMultiplier;
+
+        double adjustedCalories = Goal.ToLower() switch
+        {
+            GoalBulk => tdee + BulkCalorieDelta,
+            GoalCut => tdee + CutCalorieDelta,
+            GoalMaintenance => tdee,
+            GoalWellBeing => tdee,
+            _ => tdee
+        };
+
+        return (int)Math.Round(adjustedCalories);
+    }
+
+    public int CalculateProteinNeeds()
+    {
+        if (Weight <= 0)
+        {
+            return 0;
+        }
+
+        double proteinPerKg = Goal.ToLower() switch
+        {
+            GoalBulk => ProteinBulk,
+            GoalCut => ProteinCut,
+            GoalMaintenance => ProteinMaintenance,
+            GoalWellBeing => ProteinWellBeing,
+            _ => ProteinMaintenance
+        };
+
+        return (int)Math.Round(Weight * proteinPerKg);
+    }
+
+    public int CalculateFatNeeds()
+    {
+        int calories = CalculateCalorieNeeds();
+        if (calories <= 0)
+        {
+            return 0;
+        }
+
+        double fatRatio = Goal.ToLower() switch
+        {
+            GoalBulk or GoalCut => FatBulkCut,
+            GoalMaintenance => FatMaintenance,
+            GoalWellBeing => FatWellBeing,
+            _ => FatBulkCut
+        };
+
+        double fatCalories = calories * fatRatio;
+        return (int)Math.Round(fatCalories / CaloriesPerGramFat);
+    }
+
+    public int CalculateCarbNeeds()
+    {
+        int calories = CalculateCalorieNeeds();
+        int proteinCalories = CalculateProteinNeeds() * CaloriesPerGramProtein;
+        int fatCalories = CalculateFatNeeds() * CaloriesPerGramFat;
+
+        if (calories <= 0)
+        {
+            return 0;
+        }
+
+        int carbCalories = Math.Max(0, calories - proteinCalories - fatCalories);
+        return (int)Math.Round(carbCalories / (double)CaloriesPerGramCarbs);
+    }
+}

--- a/ClassLibrary/Models/UserSession.cs
+++ b/ClassLibrary/Models/UserSession.cs
@@ -1,0 +1,24 @@
+namespace ClassLibrary.Models;
+
+public static class UserSession
+{
+    public static string? Username { get; private set; }
+
+    public static string? Role { get; private set; }
+
+    public static int? UserId { get; private set; }
+
+    public static void Login(int userId, string username, string role)
+    {
+        UserId = userId;
+        Username = username;
+        Role = role;
+    }
+
+    public static void Logout()
+    {
+        UserId = null;
+        Username = null;
+        Role = null;
+    }
+}

--- a/ClassLibrary/Repositories/ChatRepository.cs
+++ b/ClassLibrary/Repositories/ChatRepository.cs
@@ -1,0 +1,183 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class ChatRepository(AppDbContext dbContext) : IChatRepository
+{
+    public async Task<IReadOnlyList<Conversation>> GetAllConversationsAsync(CancellationToken cancellationToken = default)
+    {
+        var conversations = await dbContext.Conversations
+            .AsNoTracking()
+            .OrderByDescending(c => c.HasUnanswered)
+            .ThenByDescending(c => c.Id)
+            .ToListAsync(cancellationToken);
+
+        foreach (var conversation in conversations)
+        {
+            var user = await dbContext.NutUsers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == conversation.UserId, cancellationToken);
+
+            conversation.Username = user?.Username ?? string.Empty;
+        }
+
+        return conversations;
+    }
+
+    public async Task<IReadOnlyList<Conversation>> GetConversationsWithUserMessagesAsync(CancellationToken cancellationToken = default)
+    {
+        var conversationIds = await dbContext.Messages
+            .AsNoTracking()
+            .Where(m => m.SenderRole != "Nutritionist")
+            .Select(m => m.ConversationId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var conversations = await dbContext.Conversations
+            .AsNoTracking()
+            .Where(c => conversationIds.Contains(c.Id))
+            .OrderByDescending(c => c.HasUnanswered)
+            .ThenByDescending(c => c.Id)
+            .ToListAsync(cancellationToken);
+
+        foreach (var conversation in conversations)
+        {
+            var user = await dbContext.NutUsers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == conversation.UserId, cancellationToken);
+
+            conversation.Username = user?.Username ?? string.Empty;
+        }
+
+        return conversations;
+    }
+
+    public async Task<IReadOnlyList<Conversation>> GetConversationsWithMessagesAsync(CancellationToken cancellationToken = default)
+    {
+        var conversationIds = await dbContext.Messages
+            .AsNoTracking()
+            .Select(m => m.ConversationId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var conversations = await dbContext.Conversations
+            .AsNoTracking()
+            .Where(c => conversationIds.Contains(c.Id))
+            .OrderByDescending(c => c.HasUnanswered)
+            .ThenByDescending(c => c.Id)
+            .ToListAsync(cancellationToken);
+
+        foreach (var conversation in conversations)
+        {
+            var user = await dbContext.NutUsers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == conversation.UserId, cancellationToken);
+
+            conversation.Username = user?.Username ?? string.Empty;
+        }
+
+        return conversations;
+    }
+
+    public async Task<IReadOnlyList<Conversation>> GetConversationsWhereNutritionistRespondedAsync(int nutritionistId, CancellationToken cancellationToken = default)
+    {
+        var conversationIds = await dbContext.Messages
+            .AsNoTracking()
+            .Where(m => m.SenderId == nutritionistId)
+            .Select(m => m.ConversationId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var conversations = await dbContext.Conversations
+            .AsNoTracking()
+            .Where(c => conversationIds.Contains(c.Id))
+            .OrderByDescending(c => c.HasUnanswered)
+            .ThenByDescending(c => c.Id)
+            .ToListAsync(cancellationToken);
+
+        foreach (var conversation in conversations)
+        {
+            var user = await dbContext.NutUsers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == conversation.UserId, cancellationToken);
+
+            conversation.Username = user?.Username ?? string.Empty;
+        }
+
+        return conversations;
+    }
+
+    public async Task<Conversation> GetOrCreateConversationForUserAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var existing = await dbContext.Conversations
+            .FirstOrDefaultAsync(c => c.UserId == userId, cancellationToken);
+
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        var conversation = new Conversation
+        {
+            UserId = userId,
+            HasUnanswered = false
+        };
+
+        dbContext.Conversations.Add(conversation);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return conversation;
+    }
+
+    public async Task<IReadOnlyList<Message>> GetMessagesForConversationAsync(int conversationId, CancellationToken cancellationToken = default)
+    {
+        var messages = await dbContext.Messages
+            .AsNoTracking()
+            .Where(m => m.ConversationId == conversationId)
+            .OrderBy(m => m.SentAt)
+            .ToListAsync(cancellationToken);
+
+        var senderIds = messages.Select(m => m.SenderId).Distinct().ToList();
+        var senders = await dbContext.NutUsers
+            .AsNoTracking()
+            .Where(u => senderIds.Contains(u.Id))
+            .ToListAsync(cancellationToken);
+
+        foreach (var message in messages)
+        {
+            var sender = senders.FirstOrDefault(s => s.Id == message.SenderId);
+            message.SenderUsername = sender?.Username ?? string.Empty;
+            message.SenderRole = sender?.Role ?? string.Empty;
+        }
+
+        return messages;
+    }
+
+    public async Task AddMessageAsync(int conversationId, int senderId, string text, bool isNutritionist, CancellationToken cancellationToken = default)
+    {
+        dbContext.Messages.Add(new Message
+        {
+            ConversationId = conversationId,
+            SenderId = senderId,
+            TextContent = text,
+            SentAt = System.DateTime.Now
+        });
+
+        var conversation = await dbContext.Conversations
+            .FirstOrDefaultAsync(c => c.Id == conversationId, cancellationToken);
+
+        if (conversation is not null)
+        {
+            conversation.HasUnanswered = !isNutritionist;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/ClassLibrary/Repositories/DailyLogRepository.cs
+++ b/ClassLibrary/Repositories/DailyLogRepository.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class DailyLogRepository(AppDbContext dbContext) : IDailyLogRepository
+{
+    public async Task AddAsync(DailyLog log, CancellationToken cancellationToken = default)
+    {
+        dbContext.DailyLogs.Add(log);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> HasAnyLogsAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.DailyLogs
+            .AnyAsync(dl => dl.UserId == userId, cancellationToken);
+    }
+
+    public async Task<DailyLog> GetNutritionTotalsForRangeAsync(int userId, DateTime startInclusive, DateTime endExclusive, CancellationToken cancellationToken = default)
+    {
+        var logs = await dbContext.DailyLogs
+            .AsNoTracking()
+            .Where(dl => dl.UserId == userId
+                      && dl.LoggedAt >= startInclusive
+                      && dl.LoggedAt < endExclusive)
+            .ToListAsync(cancellationToken);
+
+        var mealIds = logs.Select(l => l.MealId).Distinct().ToList();
+
+        var ingredientTotals = await dbContext.MealsIngredients
+            .AsNoTracking()
+            .Where(mi => mealIds.Contains(mi.MealId))
+            .Join(dbContext.Ingredients.AsNoTracking(),
+                mi => mi.FoodId,
+                i => i.FoodId,
+                (mi, i) => new { mi.Quantity, i.CaloriesPer100g, i.ProteinPer100g, i.CarbsPer100g, i.FatPer100g })
+            .ToListAsync(cancellationToken);
+
+        return new DailyLog
+        {
+            UserId = userId,
+            LoggedAt = startInclusive,
+            Calories = ingredientTotals.Sum(x => x.CaloriesPer100g * x.Quantity / 100.0),
+            Protein = ingredientTotals.Sum(x => x.ProteinPer100g * x.Quantity / 100.0),
+            Carbs = ingredientTotals.Sum(x => x.CarbsPer100g * x.Quantity / 100.0),
+            Fats = ingredientTotals.Sum(x => x.FatPer100g * x.Quantity / 100.0),
+        };
+    }
+}

--- a/ClassLibrary/Repositories/IngredientRepository.cs
+++ b/ClassLibrary/Repositories/IngredientRepository.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class IngredientRepository(AppDbContext dbContext) : IIngredientRepository
+{
+    public async Task<IReadOnlyList<Ingredient>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Ingredients
+            .AsNoTracking()
+            .OrderBy(i => i.Name)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> GetOrCreateIngredientIdAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var existing = await dbContext.Ingredients
+            .AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Name.ToLower() == name.ToLower(), cancellationToken);
+
+        if (existing is not null)
+        {
+            return existing.FoodId;
+        }
+
+        var ingredient = new Ingredient
+        {
+            Name = name,
+            CaloriesPer100g = 0,
+            ProteinPer100g = 0,
+            CarbsPer100g = 0,
+            FatPer100g = 0
+        };
+
+        dbContext.Ingredients.Add(ingredient);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return ingredient.FoodId;
+    }
+
+    public async Task<IReadOnlyList<KeyValuePair<int, string>>> SearchIngredientsAsync(string search, CancellationToken cancellationToken = default)
+    {
+        var results = await dbContext.Ingredients
+            .AsNoTracking()
+            .Where(i => i.Name.Contains(search))
+            .OrderBy(i => i.Name)
+            .Take(20)
+            .Select(i => new { i.FoodId, i.Name })
+            .ToListAsync(cancellationToken);
+
+        return results
+            .Select(r => new KeyValuePair<int, string>(r.FoodId, r.Name))
+            .ToList();
+    }
+}

--- a/ClassLibrary/Repositories/InventoryRepository.cs
+++ b/ClassLibrary/Repositories/InventoryRepository.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class InventoryRepository(AppDbContext dbContext) : IInventoryRepository
+{
+    public async Task<Inventory?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Inventories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(i => i.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Inventory>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var items = await dbContext.Inventories
+            .AsNoTracking()
+            .Where(i => i.UserId == userId)
+            .ToListAsync(cancellationToken);
+
+        foreach (var item in items)
+        {
+            var ingredient = await dbContext.Ingredients
+                .AsNoTracking()
+                .FirstOrDefaultAsync(ing => ing.FoodId == item.IngredientId, cancellationToken);
+
+            item.IngredientName = ingredient?.Name ?? string.Empty;
+        }
+
+        return items;
+    }
+
+    public async Task AddAsync(Inventory entity, CancellationToken cancellationToken = default)
+    {
+        var existing = await dbContext.Inventories
+            .FirstOrDefaultAsync(i => i.UserId == entity.UserId && i.IngredientId == entity.IngredientId, cancellationToken);
+
+        if (existing is not null)
+        {
+            existing.QuantityGrams += entity.QuantityGrams;
+        }
+        else
+        {
+            dbContext.Inventories.Add(entity);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(Inventory entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.Inventories.Update(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.Inventories.FindAsync([id], cancellationToken);
+        if (entity is not null)
+        {
+            dbContext.Inventories.Remove(entity);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/ClassLibrary/Repositories/MealPlanRepository.cs
+++ b/ClassLibrary/Repositories/MealPlanRepository.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class MealPlanRepository(AppDbContext dbContext) : IMealPlanRepository
+{
+    public async Task<MealPlan?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.MealPlans
+            .AsNoTracking()
+            .FirstOrDefaultAsync(mp => mp.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<MealPlan>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.MealPlans
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<MealPlan?> GetLatestMealPlanAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.MealPlans
+            .AsNoTracking()
+            .Where(mp => mp.UserId == userId)
+            .OrderByDescending(mp => mp.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<MealPlan?> GetTodaysMealPlanAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var today = DateTime.Today;
+        var tomorrow = today.AddDays(1);
+
+        return await dbContext.MealPlans
+            .AsNoTracking()
+            .Where(mp => mp.UserId == userId && mp.CreatedAt >= today && mp.CreatedAt < tomorrow)
+            .OrderByDescending(mp => mp.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(MealPlan entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.MealPlans.Add(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(MealPlan entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.MealPlans.Update(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.MealPlans.FindAsync([id], cancellationToken);
+        if (entity is not null)
+        {
+            dbContext.MealPlans.Remove(entity);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task<int> GeneratePersonalizedDailyMealPlanAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var meals = await dbContext.Meals.AsNoTracking().ToListAsync(cancellationToken);
+        if (meals.Count == 0)
+        {
+            throw new InvalidOperationException("No meals found in database.");
+        }
+
+        var userData = await dbContext.UserData
+            .AsNoTracking()
+            .FirstOrDefaultAsync(ud => ud.UserId == userId, cancellationToken);
+
+        int calorieNeeds = userData?.CalorieNeeds > 0 ? userData.CalorieNeeds : 2000;
+        int proteinNeeds = userData?.ProteinNeeds > 0 ? userData.ProteinNeeds : 150;
+        int carbNeeds = userData?.CarbNeeds > 0 ? userData.CarbNeeds : 200;
+        int fatNeeds = userData?.FatNeeds > 0 ? userData.FatNeeds : 65;
+        string goal = userData?.Goal ?? "general";
+
+        var mealPlan = new MealPlan
+        {
+            UserId = userId,
+            CreatedAt = DateTime.Now,
+            GoalType = goal
+        };
+
+        dbContext.MealPlans.Add(mealPlan);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        var favouriteIds = await dbContext.Favorites
+            .AsNoTracking()
+            .Where(f => f.UserId == userId)
+            .Select(f => f.MealId)
+            .ToListAsync(cancellationToken);
+
+        var pool = new List<(int id, int cal, int pro, int carb, int fat)>();
+
+        foreach (var meal in meals)
+        {
+            var ingredients = await dbContext.MealsIngredients
+                .AsNoTracking()
+                .Where(mi => mi.MealId == meal.Id)
+                .Join(dbContext.Ingredients.AsNoTracking(),
+                    mi => mi.FoodId,
+                    i => i.FoodId,
+                    (mi, i) => new { mi.Quantity, i.CaloriesPer100g, i.ProteinPer100g, i.CarbsPer100g, i.FatPer100g })
+                .ToListAsync(cancellationToken);
+
+            pool.Add((
+                meal.Id,
+                (int)ingredients.Sum(x => x.CaloriesPer100g * x.Quantity / 100.0),
+                (int)ingredients.Sum(x => x.ProteinPer100g * x.Quantity / 100.0),
+                (int)ingredients.Sum(x => x.CarbsPer100g * x.Quantity / 100.0),
+                (int)ingredients.Sum(x => x.FatPer100g * x.Quantity / 100.0)));
+        }
+
+        if (pool.Count < 3)
+        {
+            throw new InvalidOperationException("Not enough meals in the database to generate a plan.");
+        }
+
+        int bi = 0, bj = 1, bk = 2;
+        int bestScore = int.MaxValue;
+        bool bestHasFavourite = false;
+
+        for (int i = 0; i < pool.Count - 2; i++)
+        {
+            for (int j = i + 1; j < pool.Count - 1; j++)
+            {
+                for (int k = j + 1; k < pool.Count; k++)
+                {
+                    int score = Math.Abs(pool[i].cal + pool[j].cal + pool[k].cal - calorieNeeds);
+                    bool hasFav = favouriteIds.Contains(pool[i].id)
+                               || favouriteIds.Contains(pool[j].id)
+                               || favouriteIds.Contains(pool[k].id);
+
+                    bool better = score < bestScore
+                               || (hasFav && !bestHasFavourite && score <= bestScore + 100);
+
+                    if (better)
+                    {
+                        bestScore = score;
+                        bestHasFavourite = hasFav;
+                        bi = i;
+                        bj = j;
+                        bk = k;
+                    }
+                }
+            }
+        }
+
+        var selected = new[] { pool[bi], pool[bj], pool[bk] };
+        var mealTypes = new[] { "breakfast", "lunch", "dinner" };
+
+        for (int i = 0; i < selected.Length; i++)
+        {
+            dbContext.MealPlanMeals.Add(new MealPlanMeal
+            {
+                MealPlanId = mealPlan.Id,
+                MealId = selected[i].id,
+                MealType = mealTypes[i],
+                AssignedAt = DateTime.Now,
+                IsConsumed = false
+            });
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return mealPlan.Id;
+    }
+
+    public async Task<IReadOnlyList<Meal>> GetMealsForMealPlanAsync(int mealPlanId, CancellationToken cancellationToken = default)
+    {
+        var mealPlanMeals = await dbContext.MealPlanMeals
+            .AsNoTracking()
+            .Where(mpm => mpm.MealPlanId == mealPlanId)
+            .OrderBy(mpm => mpm.MealType == "breakfast" ? 1 : mpm.MealType == "lunch" ? 2 : mpm.MealType == "dinner" ? 3 : 4)
+            .ToListAsync(cancellationToken);
+
+        var mealIds = mealPlanMeals.Select(mpm => mpm.MealId).ToList();
+        var meals = await dbContext.Meals
+            .AsNoTracking()
+            .Where(m => mealIds.Contains(m.Id))
+            .ToListAsync(cancellationToken);
+
+        foreach (var meal in meals)
+        {
+            var ingredients = await dbContext.MealsIngredients
+                .AsNoTracking()
+                .Where(mi => mi.MealId == meal.Id)
+                .Join(dbContext.Ingredients.AsNoTracking(),
+                    mi => mi.FoodId,
+                    i => i.FoodId,
+                    (mi, i) => new { mi.Quantity, i.CaloriesPer100g, i.ProteinPer100g, i.CarbsPer100g, i.FatPer100g })
+                .ToListAsync(cancellationToken);
+
+            meal.Calories = (int)ingredients.Sum(x => x.CaloriesPer100g * x.Quantity / 100.0);
+            meal.Protein = (int)ingredients.Sum(x => x.ProteinPer100g * x.Quantity / 100.0);
+            meal.Carbs = (int)ingredients.Sum(x => x.CarbsPer100g * x.Quantity / 100.0);
+            meal.Fat = (int)ingredients.Sum(x => x.FatPer100g * x.Quantity / 100.0);
+        }
+
+        return meals;
+    }
+
+    public async Task<IReadOnlyList<IngredientViewModel>> GetIngredientsForMealAsync(int mealId, CancellationToken cancellationToken = default)
+    {
+        var ingredients = await dbContext.MealsIngredients
+            .AsNoTracking()
+            .Where(mi => mi.MealId == mealId)
+            .Join(dbContext.Ingredients.AsNoTracking(),
+                mi => mi.FoodId,
+                i => i.FoodId,
+                (mi, i) => new { mi.FoodId, i.Name, mi.Quantity, i.CaloriesPer100g, i.ProteinPer100g, i.CarbsPer100g, i.FatPer100g })
+            .OrderByDescending(x => x.Quantity)
+            .ToListAsync(cancellationToken);
+
+        return ingredients.Select(x => new IngredientViewModel
+        {
+            IngredientId = x.FoodId,
+            Name = x.Name,
+            Quantity = x.Quantity,
+            Calories = Math.Round(x.CaloriesPer100g * x.Quantity / 100, 1),
+            Protein = Math.Round(x.ProteinPer100g * x.Quantity / 100, 1),
+            Carbs = Math.Round(x.CarbsPer100g * x.Quantity / 100, 1),
+            Fat = Math.Round(x.FatPer100g * x.Quantity / 100, 1),
+        }).ToList();
+    }
+
+    public async Task SaveMealsToDailyLogAsync(int userId, IReadOnlyList<Meal> meals, CancellationToken cancellationToken = default)
+    {
+        foreach (var meal in meals)
+        {
+            dbContext.DailyLogs.Add(new DailyLog
+            {
+                UserId = userId,
+                MealId = meal.Id,
+                Calories = meal.Calories,
+                LoggedAt = DateTime.Now
+            });
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task SaveMealToDailyLogAsync(int userId, int mealId, int calories, CancellationToken cancellationToken = default)
+    {
+        dbContext.DailyLogs.Add(new DailyLog
+        {
+            UserId = userId,
+            MealId = mealId,
+            Calories = calories,
+            LoggedAt = DateTime.Now
+        });
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/ClassLibrary/Repositories/MealRepository.cs
+++ b/ClassLibrary/Repositories/MealRepository.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class MealRepository(AppDbContext dbContext) : IMealRepository
+{
+    public async Task<Meal?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Meals
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Meal>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Meals
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Meal>> GetFilteredMealsAsync(MealFilter filter, CancellationToken cancellationToken = default)
+    {
+        var query = dbContext.Meals.AsNoTracking().AsQueryable();
+
+        if (filter.IsKeto)
+        {
+            query = query.Where(m => m.IsKeto);
+        }
+
+        if (filter.IsVegan)
+        {
+            query = query.Where(m => m.IsVegan);
+        }
+
+        if (filter.IsNutFree)
+        {
+            query = query.Where(m => m.IsNutFree);
+        }
+
+        if (filter.IsLactoseFree)
+        {
+            query = query.Where(m => m.IsLactoseFree);
+        }
+
+        if (filter.IsGlutenFree)
+        {
+            query = query.Where(m => m.IsGlutenFree);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.SearchTerm))
+        {
+            query = query.Where(m => m.Name.Contains(filter.SearchTerm));
+        }
+
+        var meals = await query.ToListAsync(cancellationToken);
+
+        if (filter.IsFavoriteOnly)
+        {
+            var favoriteMealIds = await dbContext.Favorites
+                .AsNoTracking()
+                .Select(f => f.MealId)
+                .ToListAsync(cancellationToken);
+
+            meals = meals.Where(m => favoriteMealIds.Contains(m.Id)).ToList();
+        }
+
+        foreach (var meal in meals)
+        {
+            var ingredients = await dbContext.MealsIngredients
+                .AsNoTracking()
+                .Where(mi => mi.MealId == meal.Id)
+                .Join(dbContext.Ingredients.AsNoTracking(),
+                    mi => mi.FoodId,
+                    i => i.FoodId,
+                    (mi, i) => new { mi.Quantity, i.CaloriesPer100g, i.ProteinPer100g, i.CarbsPer100g, i.FatPer100g })
+                .ToListAsync(cancellationToken);
+
+            meal.Calories = (int)ingredients.Sum(x => x.CaloriesPer100g * x.Quantity / 100.0);
+            meal.Protein = (int)ingredients.Sum(x => x.ProteinPer100g * x.Quantity / 100.0);
+            meal.Carbs = (int)ingredients.Sum(x => x.CarbsPer100g * x.Quantity / 100.0);
+            meal.Fat = (int)ingredients.Sum(x => x.FatPer100g * x.Quantity / 100.0);
+        }
+
+        return meals;
+    }
+
+    public async Task AddAsync(Meal entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.Meals.Add(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(Meal entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.Meals.Update(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.Meals.FindAsync([id], cancellationToken);
+        if (entity is not null)
+        {
+            dbContext.Meals.Remove(entity);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task SetFavoriteAsync(int userId, int mealId, bool isFavorite, CancellationToken cancellationToken = default)
+    {
+        var existing = await dbContext.Favorites
+            .FirstOrDefaultAsync(f => f.UserId == userId && f.MealId == mealId, cancellationToken);
+
+        if (isFavorite && existing is null)
+        {
+            dbContext.Favorites.Add(new Favorite { UserId = userId, MealId = mealId });
+        }
+        else if (!isFavorite && existing is not null)
+        {
+            dbContext.Favorites.Remove(existing);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<string>> GetIngredientLinesForMealAsync(int mealId, CancellationToken cancellationToken = default)
+    {
+        var ingredients = await dbContext.MealsIngredients
+            .AsNoTracking()
+            .Where(mi => mi.MealId == mealId)
+            .Join(dbContext.Ingredients.AsNoTracking(),
+                mi => mi.FoodId,
+                i => i.FoodId,
+                (mi, i) => new { i.Name, mi.Quantity })
+            .OrderByDescending(x => x.Quantity)
+            .ThenBy(x => x.Name)
+            .ToListAsync(cancellationToken);
+
+        return ingredients
+            .Select(x => $"- {x.Name} ({x.Quantity:0.#}g)")
+            .ToList();
+    }
+}

--- a/ClassLibrary/Repositories/NutUserRepository.cs
+++ b/ClassLibrary/Repositories/NutUserRepository.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class NutUserRepository(AppDbContext dbContext) : INutUserRepository
+{
+    public async Task<NutUser?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.NutUsers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<NutUser>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.NutUsers
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(NutUser entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.NutUsers.Add(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(NutUser entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.NutUsers.Update(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.NutUsers.FindAsync([id], cancellationToken);
+        if (entity is not null)
+        {
+            dbContext.NutUsers.Remove(entity);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task<NutUser?> GetByUsernameAndPasswordAsync(string username, string password, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.NutUsers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Username == username && u.Password == password, cancellationToken);
+    }
+
+    public async Task AddUserDataAsync(UserData data, CancellationToken cancellationToken = default)
+    {
+        dbContext.UserData.Add(data);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<UserData?> GetUserDataByUserIdAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.UserData
+            .AsNoTracking()
+            .FirstOrDefaultAsync(ud => ud.UserId == userId, cancellationToken);
+    }
+
+    public async Task UpdateUserDataAsync(UserData data, CancellationToken cancellationToken = default)
+    {
+        dbContext.UserData.Update(data);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/ClassLibrary/Repositories/ReminderRepository.cs
+++ b/ClassLibrary/Repositories/ReminderRepository.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class ReminderRepository(AppDbContext dbContext) : IReminderRepository
+{
+    public async Task<Reminder?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Reminders
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Reminder>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Reminders
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Reminder>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Reminders
+            .AsNoTracking()
+            .Where(r => r.UserId == userId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Reminder entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.Reminders.Add(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(Reminder entity, CancellationToken cancellationToken = default)
+    {
+        dbContext.Reminders.Update(entity);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.Reminders.FindAsync([id], cancellationToken);
+        if (entity is not null)
+        {
+            dbContext.Reminders.Remove(entity);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task<Reminder?> GetNextReminderAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.Now;
+        var today = now.Date.ToString("yyyy-MM-dd");
+        var currentTime = now.TimeOfDay;
+
+        var reminders = await dbContext.Reminders
+            .AsNoTracking()
+            .Where(r => r.UserId == userId)
+            .ToListAsync(cancellationToken);
+
+        return reminders
+            .Where(r => string.Compare(r.ReminderDate, today, StringComparison.Ordinal) > 0
+                     || (r.ReminderDate == today && r.Time >= currentTime))
+            .OrderBy(r => r.ReminderDate)
+            .ThenBy(r => r.Time)
+            .FirstOrDefault();
+    }
+}

--- a/ClassLibrary/Repositories/ShoppingListRepository.cs
+++ b/ClassLibrary/Repositories/ShoppingListRepository.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class ShoppingListRepository(AppDbContext dbContext) : IShoppingListRepository
+{
+    public async Task<ShoppingItem?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var item = await dbContext.ShoppingItems
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+
+        if (item is not null)
+        {
+            var ingredient = await dbContext.Ingredients
+                .AsNoTracking()
+                .FirstOrDefaultAsync(i => i.FoodId == item.IngredientId, cancellationToken);
+
+            item.IngredientName = ingredient?.Name ?? string.Empty;
+        }
+
+        return item;
+    }
+
+    public async Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var items = await dbContext.ShoppingItems
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        foreach (var item in items)
+        {
+            var ingredient = await dbContext.Ingredients
+                .AsNoTracking()
+                .FirstOrDefaultAsync(i => i.FoodId == item.IngredientId, cancellationToken);
+
+            item.IngredientName = ingredient?.Name ?? string.Empty;
+        }
+
+        return items;
+    }
+
+    public async Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var items = await dbContext.ShoppingItems
+            .AsNoTracking()
+            .Where(s => s.UserId == userId)
+            .ToListAsync(cancellationToken);
+
+        foreach (var item in items)
+        {
+            var ingredient = await dbContext.Ingredients
+                .AsNoTracking()
+                .FirstOrDefaultAsync(i => i.FoodId == item.IngredientId, cancellationToken);
+
+            item.IngredientName = ingredient?.Name ?? string.Empty;
+        }
+
+        return items;
+    }
+
+    public async Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default)
+    {
+        var item = await dbContext.ShoppingItems
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.UserId == userId && s.IngredientId == ingredientId, cancellationToken);
+
+        if (item is not null)
+        {
+            var ingredient = await dbContext.Ingredients
+                .AsNoTracking()
+                .FirstOrDefaultAsync(i => i.FoodId == item.IngredientId, cancellationToken);
+
+            item.IngredientName = ingredient?.Name ?? string.Empty;
+        }
+
+        return item;
+    }
+
+    public async Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default)
+    {
+        dbContext.ShoppingItems.Add(item);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default)
+    {
+        dbContext.ShoppingItems.Update(item);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await dbContext.ShoppingItems.FindAsync([id], cancellationToken);
+        if (entity is not null)
+        {
+            dbContext.ShoppingItems.Remove(entity);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task<IReadOnlyList<ShoppingItem>> GetIngredientsNeededFromMealPlanAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var today = DateTime.Today;
+        var tomorrow = today.AddDays(1);
+
+        var todaysPlan = await dbContext.MealPlans
+            .AsNoTracking()
+            .Where(mp => mp.UserId == userId && mp.CreatedAt >= today && mp.CreatedAt < tomorrow)
+            .OrderByDescending(mp => mp.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (todaysPlan is null)
+        {
+            return new List<ShoppingItem>();
+        }
+
+        var mealIds = await dbContext.MealPlanMeals
+            .AsNoTracking()
+            .Where(mpm => mpm.MealPlanId == todaysPlan.Id)
+            .Select(mpm => mpm.MealId)
+            .ToListAsync(cancellationToken);
+
+        var neededIngredients = await dbContext.MealsIngredients
+            .AsNoTracking()
+            .Where(mi => mealIds.Contains(mi.MealId))
+            .GroupBy(mi => mi.FoodId)
+            .Select(g => new
+            {
+                FoodId = g.Key,
+                TotalQuantity = g.Sum(mi => mi.Quantity)
+            })
+            .ToListAsync(cancellationToken);
+
+        var items = new List<ShoppingItem>();
+
+        foreach (var needed in neededIngredients)
+        {
+            var inventory = await dbContext.Inventories
+                .AsNoTracking()
+                .FirstOrDefaultAsync(inv => inv.UserId == userId && inv.IngredientId == needed.FoodId, cancellationToken);
+
+            double inventoryQty = inventory?.QuantityGrams ?? 0;
+            double quantityNeeded = needed.TotalQuantity - inventoryQty;
+
+            if (quantityNeeded > 0)
+            {
+                var ingredient = await dbContext.Ingredients
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(i => i.FoodId == needed.FoodId, cancellationToken);
+
+                items.Add(new ShoppingItem
+                {
+                    UserId = userId,
+                    IngredientId = needed.FoodId,
+                    IngredientName = ingredient?.Name ?? string.Empty,
+                    QuantityGrams = quantityNeeded,
+                    IsChecked = false
+                });
+            }
+        }
+
+        return items;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds generic `IRepository<T>` interface with CRUD + CancellationToken support
- Adds 9 NUT-specific repository interfaces (`ClassLibrary/IRepositories/`) with CancellationToken
- Implements all 9 repositories using EF Core `AppDbContext`:
  - `NutUserRepository` - NutUser + UserData CRUD, authentication lookup
  - `MealRepository` - Meal CRUD, filtered queries, favorites, ingredient lines
  - `MealPlanRepository` - MealPlan CRUD, personalized daily plan generation, meal-to-log saving
  - `IngredientRepository` - Ingredient search, get-or-create by name
  - `InventoryRepository` - Inventory CRUD with auto-merge on duplicate ingredients
  - `ShoppingListRepository` - Shopping list CRUD, meal-plan-based ingredient needs calculation
  - `ReminderRepository` - Reminder CRUD, next-reminder lookup
  - `DailyLogRepository` - DailyLog CRUD, nutrition totals aggregation
  - `ChatRepository` - Conversation management, message history, nutritionist filtering
- Adds join entity models (`Favorite`, `MealsIngredient`, `MealPlanMeal`) with composite keys
- Adapts all SQLite raw-SQL operations to EF Core LINQ queries with `AsNoTracking()` for reads
- Creates `IngredientViewModel` DTO for `IMealPlanRepository.GetIngredientsForMeal`

## Issues Closed
Closes #48, #49, #50, #51, #52, #53, #54, #55, #56
