### PR TITLE
Integrate shopping list item+repo

### DIFF
--- a/ClassLibrary/Data/AppDbContext.cs
+++ b/ClassLibrary/Data/AppDbContext.cs
@@ -26,6 +26,8 @@ public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbCon
 
     public DbSet<Message> Messages { get; set; } = default!;
 
+    public DbSet<ShoppingItem> ShoppingItems { get; set; } = default!;
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<ClientNutritionPlan>()

--- a/ClassLibrary/Extensions/ServiceCollectionExtensions.cs
+++ b/ClassLibrary/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IChatRepository, ChatRepository>();
         services.AddScoped<IDailyLogRepository, DailyLogRepository>();
         services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
+        services.AddScoped<IWorkoutAnalyticsRepository, WorkoutAnalyticsRepository>();
 
         return services;
     }

--- a/ClassLibrary/Extensions/ServiceCollectionExtensions.cs
+++ b/ClassLibrary/Extensions/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IRepositoryNotification, RepositoryNotification>();
         services.AddScoped<IRepositoryNutrition, RepositoryNutrition>();
         services.AddScoped<IChatRepository, ChatRepository>();
+        services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
 
         return services;
     }

--- a/ClassLibrary/IRepositories/IShoppingListRepository.cs
+++ b/ClassLibrary/IRepositories/IShoppingListRepository.cs
@@ -5,10 +5,10 @@ namespace ClassLibrary.IRepositories
     public interface IShoppingListRepository
     {
         Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default);
-        Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+        Task DeleteAsync(int shoppingItemId, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default);
         Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
-        Task<ShoppingItem?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+        Task<ShoppingItem?> GetByIdAsync(int shoppingItemId, CancellationToken cancellationToken = default);
         Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default);
         Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default);
     }

--- a/ClassLibrary/IRepositories/IShoppingListRepository.cs
+++ b/ClassLibrary/IRepositories/IShoppingListRepository.cs
@@ -1,15 +1,17 @@
-﻿using ClassLibrary.Models;
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
 
-namespace ClassLibrary.IRepositories
+namespace ClassLibrary.IRepositories;
+
+public interface IShoppingListRepository
 {
-    public interface IShoppingListRepository
-    {
-        Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default);
-        Task DeleteAsync(int shoppingItemId, CancellationToken cancellationToken = default);
-        Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default);
-        Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
-        Task<ShoppingItem?> GetByIdAsync(int shoppingItemId, CancellationToken cancellationToken = default);
-        Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default);
-        Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default);
-    }
+    Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default);
+    Task DeleteAsync(int shoppingItemId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+    Task<ShoppingItem?> GetByIdAsync(int shoppingItemId, CancellationToken cancellationToken = default);
+    Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default);
+    Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default);
 }

--- a/ClassLibrary/IRepositories/IShoppingListRepository.cs
+++ b/ClassLibrary/IRepositories/IShoppingListRepository.cs
@@ -1,0 +1,15 @@
+﻿using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories
+{
+    public interface IShoppingListRepository
+    {
+        Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default);
+        Task DeleteAsync(int id, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+        Task<ShoppingItem?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+        Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default);
+        Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default);
+    }
+}

--- a/ClassLibrary/IRepositories/IWorkoutAnalyticsRepository.cs
+++ b/ClassLibrary/IRepositories/IWorkoutAnalyticsRepository.cs
@@ -1,0 +1,14 @@
+﻿using ClassLibrary.Models;
+
+namespace ClassLibrary.Repositories
+{
+    public interface IWorkoutAnalyticsRepository
+    {
+        Task<int> GetTotalWorkoutCountAsync(int clientId, CancellationToken cancellationToken = default);
+        Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default);
+        Task<(IReadOnlyList<WorkoutLog> Items, int TotalCount)> GetWorkoutHistoryPageAsync(int clientId, int skip, int take, CancellationToken cancellationToken = default);
+        Task<WorkoutLog?> GetWorkoutLogWithSetsAsync(int clientId, int workoutLogId, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(int clientId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default);
+        Task SaveWorkoutAsync(WorkoutLog log, CancellationToken cancellationToken = default);
+    }
+}

--- a/ClassLibrary/IRepositories/IWorkoutAnalyticsRepository.cs
+++ b/ClassLibrary/IRepositories/IWorkoutAnalyticsRepository.cs
@@ -4,9 +4,8 @@ namespace ClassLibrary.Repositories
 {
     public interface IWorkoutAnalyticsRepository
     {
-        Task<int> GetTotalWorkoutCountAsync(int clientId, CancellationToken cancellationToken = default);
         Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default);
-        Task<(IReadOnlyList<WorkoutLog> Items, int TotalCount)> GetWorkoutHistoryPageAsync(int clientId, int skip, int take, CancellationToken cancellationToken = default);
+        Task<(IReadOnlyList<WorkoutLog> WorkoutLogs, int TotalCount)> GetWorkoutHistoryPageAsync(int clientId, int skip, int take, CancellationToken cancellationToken = default);
         Task<WorkoutLog?> GetWorkoutLogWithSetsAsync(int clientId, int workoutLogId, CancellationToken cancellationToken = default);
         Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(int clientId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default);
         Task SaveWorkoutAsync(WorkoutLog log, CancellationToken cancellationToken = default);

--- a/ClassLibrary/IRepositories/IWorkoutAnalyticsRepository.cs
+++ b/ClassLibrary/IRepositories/IWorkoutAnalyticsRepository.cs
@@ -1,13 +1,16 @@
-﻿using ClassLibrary.Models;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
 
-namespace ClassLibrary.Repositories
+namespace ClassLibrary.IRepositories;
+
+public interface IWorkoutAnalyticsRepository
 {
-    public interface IWorkoutAnalyticsRepository
-    {
-        Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default);
-        Task<(IReadOnlyList<WorkoutLog> WorkoutLogs, int TotalCount)> GetWorkoutHistoryPageAsync(int clientId, int skip, int take, CancellationToken cancellationToken = default);
-        Task<WorkoutLog?> GetWorkoutLogWithSetsAsync(int clientId, int workoutLogId, CancellationToken cancellationToken = default);
-        Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(int clientId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default);
-        Task SaveWorkoutAsync(WorkoutLog log, CancellationToken cancellationToken = default);
-    }
+    Task SaveWorkoutAsync(WorkoutLog workoutLog, CancellationToken cancellationToken = default);
+    Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(int clientId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default);
+    Task<(IReadOnlyList<WorkoutLog> WorkoutLogs, int TotalCount)> GetWorkoutHistoryPageAsync(int clientId, int skip, int take, CancellationToken cancellationToken = default);
+    Task<WorkoutLog?> GetWorkoutLogWithSetsAsync(int clientId, int workoutLogId, CancellationToken cancellationToken = default);
 }

--- a/ClassLibrary/Models/ShoppingItem.cs
+++ b/ClassLibrary/Models/ShoppingItem.cs
@@ -2,7 +2,7 @@
 
 public class ShoppingItem
 {
-    public int Id { get; set; }
+    public int ShoppingItemId { get; set; }
     public int UserId { get; set; }
     public User User { get; set; } = null!;
     public int IngredientId { get; set; }

--- a/ClassLibrary/Models/ShoppingItem.cs
+++ b/ClassLibrary/Models/ShoppingItem.cs
@@ -1,0 +1,14 @@
+﻿namespace ClassLibrary.Models;
+
+public class ShoppingItem
+{
+    public int Id { get; set; }
+    public int UserId { get; set; }
+    public User User { get; set; } = null!;
+    public int IngredientId { get; set; }
+    public Ingredient Ingredient { get; set; } = null!;
+
+    public double QuantityGrams { get; set; }
+
+    public bool IsChecked { get; set; }
+}

--- a/ClassLibrary/Repositories/ShoppingListRepository.cs
+++ b/ClassLibrary/Repositories/ShoppingListRepository.cs
@@ -9,55 +9,62 @@ using ClassLibrary.Data;
 using ClassLibrary.Models;
 using ClassLibrary.IRepositories;
 
-public sealed class ShoppingListRepository(AppDbContext dbContext) : IShoppingListRepository
+public sealed class ShoppingListRepository : IShoppingListRepository
 {
+    private readonly AppDbContext _databaseContext;
+
+    public ShoppingListRepository(AppDbContext databaseContext)
+    {
+        _databaseContext = databaseContext;
+    }
+
     public async Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default)
     {
-        await dbContext.ShoppingItems.AddAsync(item, cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await _databaseContext.ShoppingItems.AddAsync(item, cancellationToken);
+        await _databaseContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default)
     {
-        return await dbContext.ShoppingItems
+        return await _databaseContext.ShoppingItems
             .AsNoTracking()
-            .Include(s => s.Ingredient)
+            .Include(shoppingItem => shoppingItem.Ingredient)
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<ShoppingItem?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    public async Task<ShoppingItem?> GetByIdAsync(int shoppingItemId, CancellationToken cancellationToken = default)
     {
-        return await dbContext.ShoppingItems
-            .Include(s => s.Ingredient)
-            .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+        return await _databaseContext.ShoppingItems
+            .Include(shoppingItem => shoppingItem.Ingredient)
+            .FirstOrDefaultAsync(shoppingItem => shoppingItem.ShoppingItemId == shoppingItemId, cancellationToken);
     }
 
     public async Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default)
     {
-        return await dbContext.ShoppingItems
-            .Include(s => s.Ingredient)
-            .FirstOrDefaultAsync(s => s.UserId == userId && s.IngredientId == ingredientId, cancellationToken);
+        return await _databaseContext.ShoppingItems
+            .Include(shoppingItem => shoppingItem.Ingredient)
+            .FirstOrDefaultAsync(shoppingItem => shoppingItem.UserId == userId && shoppingItem.IngredientId == ingredientId, cancellationToken);
     }
 
     public async Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default)
     {
-        return await dbContext.ShoppingItems
+        return await _databaseContext.ShoppingItems
             .AsNoTracking()
-            .Include(s => s.Ingredient)
-            .Where(s => s.UserId == userId)
+            .Include(shoppingItem => shoppingItem.Ingredient)
+            .Where(shoppingItem => shoppingItem.UserId == userId)
             .ToListAsync(cancellationToken);
     }
 
     public async Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default)
     {
-        dbContext.ShoppingItems.Update(item);
-        await dbContext.SaveChangesAsync(cancellationToken);
+        _databaseContext.ShoppingItems.Update(item);
+        await _databaseContext.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    public async Task DeleteAsync(int shoppingItemId, CancellationToken cancellationToken = default)
     {
-        await dbContext.ShoppingItems
-            .Where(s => s.Id == id)
+        await _databaseContext.ShoppingItems
+            .Where(shoppingItem => shoppingItem.ShoppingItemId == shoppingItemId)
             .ExecuteDeleteAsync(cancellationToken);
     }
 }

--- a/ClassLibrary/Repositories/ShoppingListRepository.cs
+++ b/ClassLibrary/Repositories/ShoppingListRepository.cs
@@ -1,6 +1,4 @@
-﻿namespace ClassLibrary.Repositories;
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,24 +7,26 @@ using ClassLibrary.Data;
 using ClassLibrary.Models;
 using ClassLibrary.IRepositories;
 
+namespace ClassLibrary.Repositories;
+
 public sealed class ShoppingListRepository : IShoppingListRepository
 {
-    private readonly AppDbContext _databaseContext;
+    private readonly AppDbContext databaseContext;
 
     public ShoppingListRepository(AppDbContext databaseContext)
     {
-        _databaseContext = databaseContext;
+        this.databaseContext = databaseContext;
     }
 
     public async Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default)
     {
-        await _databaseContext.ShoppingItems.AddAsync(item, cancellationToken);
-        await _databaseContext.SaveChangesAsync(cancellationToken);
+        await databaseContext.ShoppingItems.AddAsync(item, cancellationToken);
+        await databaseContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default)
     {
-        return await _databaseContext.ShoppingItems
+        return await databaseContext.ShoppingItems
             .AsNoTracking()
             .Include(shoppingItem => shoppingItem.Ingredient)
             .ToListAsync(cancellationToken);
@@ -34,21 +34,21 @@ public sealed class ShoppingListRepository : IShoppingListRepository
 
     public async Task<ShoppingItem?> GetByIdAsync(int shoppingItemId, CancellationToken cancellationToken = default)
     {
-        return await _databaseContext.ShoppingItems
+        return await databaseContext.ShoppingItems
             .Include(shoppingItem => shoppingItem.Ingredient)
             .FirstOrDefaultAsync(shoppingItem => shoppingItem.ShoppingItemId == shoppingItemId, cancellationToken);
     }
 
     public async Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default)
     {
-        return await _databaseContext.ShoppingItems
+        return await databaseContext.ShoppingItems
             .Include(shoppingItem => shoppingItem.Ingredient)
             .FirstOrDefaultAsync(shoppingItem => shoppingItem.UserId == userId && shoppingItem.IngredientId == ingredientId, cancellationToken);
     }
 
     public async Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default)
     {
-        return await _databaseContext.ShoppingItems
+        return await databaseContext.ShoppingItems
             .AsNoTracking()
             .Include(shoppingItem => shoppingItem.Ingredient)
             .Where(shoppingItem => shoppingItem.UserId == userId)
@@ -57,13 +57,13 @@ public sealed class ShoppingListRepository : IShoppingListRepository
 
     public async Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default)
     {
-        _databaseContext.ShoppingItems.Update(item);
-        await _databaseContext.SaveChangesAsync(cancellationToken);
+        databaseContext.ShoppingItems.Update(item);
+        await databaseContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task DeleteAsync(int shoppingItemId, CancellationToken cancellationToken = default)
     {
-        await _databaseContext.ShoppingItems
+        await databaseContext.ShoppingItems
             .Where(shoppingItem => shoppingItem.ShoppingItemId == shoppingItemId)
             .ExecuteDeleteAsync(cancellationToken);
     }

--- a/ClassLibrary/Repositories/ShoppingListRepository.cs
+++ b/ClassLibrary/Repositories/ShoppingListRepository.cs
@@ -1,0 +1,63 @@
+﻿namespace ClassLibrary.Repositories;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ClassLibrary.Data;
+using ClassLibrary.Models;
+using ClassLibrary.IRepositories;
+
+public sealed class ShoppingListRepository(AppDbContext dbContext) : IShoppingListRepository
+{
+    public async Task AddAsync(ShoppingItem item, CancellationToken cancellationToken = default)
+    {
+        await dbContext.ShoppingItems.AddAsync(item, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ShoppingItem>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.ShoppingItems
+            .AsNoTracking()
+            .Include(s => s.Ingredient)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<ShoppingItem?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.ShoppingItems
+            .Include(s => s.Ingredient)
+            .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+    }
+
+    public async Task<ShoppingItem?> GetByUserAndIngredientAsync(int userId, int ingredientId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.ShoppingItems
+            .Include(s => s.Ingredient)
+            .FirstOrDefaultAsync(s => s.UserId == userId && s.IngredientId == ingredientId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ShoppingItem>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.ShoppingItems
+            .AsNoTracking()
+            .Include(s => s.Ingredient)
+            .Where(s => s.UserId == userId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(ShoppingItem item, CancellationToken cancellationToken = default)
+    {
+        dbContext.ShoppingItems.Update(item);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        await dbContext.ShoppingItems
+            .Where(s => s.Id == id)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+}

--- a/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
+++ b/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
@@ -1,0 +1,68 @@
+﻿namespace ClassLibrary.Repositories;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ClassLibrary.Data;
+using ClassLibrary.Models;
+using ClassLibrary.IRepositories;
+
+public sealed class WorkoutAnalyticsRepository(AppDbContext dbContext) : IWorkoutAnalyticsRepository
+{
+    public async Task SaveWorkoutAsync(WorkoutLog log, CancellationToken cancellationToken = default)
+    {
+        await dbContext.WorkoutLogs.AddAsync(log, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.WorkoutLogs
+            .CountAsync(wl => wl.Client.ClientId == clientId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(
+        int clientId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.WorkoutLogs
+            .AsNoTracking()
+            .Where(wl => wl.Client.ClientId == clientId && wl.Date >= startDate && wl.Date <= endDate)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> GetTotalWorkoutCountAsync(int clientId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.WorkoutLogs
+            .CountAsync(wl => wl.Client.ClientId == clientId, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<WorkoutLog> Items, int TotalCount)> GetWorkoutHistoryPageAsync(
+        int clientId, int skip, int take, CancellationToken cancellationToken = default)
+    {
+        var totalCount = await dbContext.WorkoutLogs
+            .CountAsync(wl => wl.Client.ClientId == clientId, cancellationToken);
+
+        var items = await dbContext.WorkoutLogs
+            .AsNoTracking()
+            .Where(wl => wl.Client.ClientId == clientId)
+            .OrderByDescending(wl => wl.Date)
+            .ThenByDescending(wl => wl.WorkoutLogId)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public async Task<WorkoutLog?> GetWorkoutLogWithSetsAsync(
+        int clientId, int workoutLogId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.WorkoutLogs
+            .AsNoTracking()
+            .Include(wl => wl.Exercises)
+            .FirstOrDefaultAsync(wl => wl.WorkoutLogId == workoutLogId && wl.Client.ClientId == clientId, cancellationToken);
+    }
+}

--- a/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
+++ b/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
@@ -21,7 +21,7 @@ public sealed class WorkoutAnalyticsRepository(AppDbContext dbContext) : IWorkou
     public async Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default)
     {
         return await dbContext.WorkoutLogs
-            .CountAsync(wl => wl.Client.ClientId == clientId, cancellationToken);
+            .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
     }
 
     public async Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(
@@ -29,27 +29,27 @@ public sealed class WorkoutAnalyticsRepository(AppDbContext dbContext) : IWorkou
     {
         return await dbContext.WorkoutLogs
             .AsNoTracking()
-            .Where(wl => wl.Client.ClientId == clientId && wl.Date >= startDate && wl.Date <= endDate)
+            .Where(workoutLog => workoutLog.Client.ClientId == clientId && workoutLog.Date >= startDate && workoutLog.Date <= endDate)
             .ToListAsync(cancellationToken);
     }
 
     public async Task<int> GetTotalWorkoutCountAsync(int clientId, CancellationToken cancellationToken = default)
     {
         return await dbContext.WorkoutLogs
-            .CountAsync(wl => wl.Client.ClientId == clientId, cancellationToken);
+            .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
     }
 
     public async Task<(IReadOnlyList<WorkoutLog> Items, int TotalCount)> GetWorkoutHistoryPageAsync(
         int clientId, int skip, int take, CancellationToken cancellationToken = default)
     {
         var totalCount = await dbContext.WorkoutLogs
-            .CountAsync(wl => wl.Client.ClientId == clientId, cancellationToken);
+            .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
 
         var items = await dbContext.WorkoutLogs
             .AsNoTracking()
-            .Where(wl => wl.Client.ClientId == clientId)
-            .OrderByDescending(wl => wl.Date)
-            .ThenByDescending(wl => wl.WorkoutLogId)
+            .Where(workoutLog => workoutLog.Client.ClientId == clientId)
+            .OrderByDescending(workoutLog => workoutLog.Date)
+            .ThenByDescending(workoutLog => workoutLog.WorkoutLogId)
             .Skip(skip)
             .Take(take)
             .ToListAsync(cancellationToken);
@@ -62,7 +62,7 @@ public sealed class WorkoutAnalyticsRepository(AppDbContext dbContext) : IWorkou
     {
         return await dbContext.WorkoutLogs
             .AsNoTracking()
-            .Include(wl => wl.Exercises)
-            .FirstOrDefaultAsync(wl => wl.WorkoutLogId == workoutLogId && wl.Client.ClientId == clientId, cancellationToken);
+            .Include(workoutLog => workoutLog.Exercises)
+            .FirstOrDefaultAsync(workoutLog => workoutLog.WorkoutLogId == workoutLogId && workoutLog.Client.ClientId == clientId, cancellationToken);
     }
 }

--- a/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
+++ b/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
@@ -1,6 +1,4 @@
-﻿namespace ClassLibrary.Repositories;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -10,31 +8,33 @@ using ClassLibrary.Data;
 using ClassLibrary.Models;
 using ClassLibrary.IRepositories;
 
+namespace ClassLibrary.Repositories;
+
 public sealed class WorkoutAnalyticsRepository : IWorkoutAnalyticsRepository
 {
-    private readonly AppDbContext _databaseContext;
+    private readonly AppDbContext databaseContext;
 
     public WorkoutAnalyticsRepository(AppDbContext databaseContext)
     {
-        _databaseContext = databaseContext;
+        this.databaseContext = databaseContext;
     }
 
     public async Task SaveWorkoutAsync(WorkoutLog workoutLog, CancellationToken cancellationToken = default)
     {
-        await _databaseContext.WorkoutLogs.AddAsync(workoutLog, cancellationToken);
-        await _databaseContext.SaveChangesAsync(cancellationToken);
+        await databaseContext.WorkoutLogs.AddAsync(workoutLog, cancellationToken);
+        await databaseContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default)
     {
-        return await _databaseContext.WorkoutLogs
+        return await databaseContext.WorkoutLogs
             .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
     }
 
     public async Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(
         int clientId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
     {
-        return await _databaseContext.WorkoutLogs
+        return await databaseContext.WorkoutLogs
             .AsNoTracking()
             .Where(workoutLog => workoutLog.Client.ClientId == clientId && workoutLog.Date >= startDate && workoutLog.Date <= endDate)
             .ToListAsync(cancellationToken);
@@ -43,10 +43,10 @@ public sealed class WorkoutAnalyticsRepository : IWorkoutAnalyticsRepository
     public async Task<(IReadOnlyList<WorkoutLog> WorkoutLogs, int TotalCount)> GetWorkoutHistoryPageAsync(
         int clientId, int skip, int take, CancellationToken cancellationToken = default)
     {
-        var totalCount = await _databaseContext.WorkoutLogs
+        var totalCount = await databaseContext.WorkoutLogs
             .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
 
-        var workoutLogs = await _databaseContext.WorkoutLogs
+        var workoutLogs = await databaseContext.WorkoutLogs
             .AsNoTracking()
             .Where(workoutLog => workoutLog.Client.ClientId == clientId)
             .OrderByDescending(workoutLog => workoutLog.Date)
@@ -61,7 +61,7 @@ public sealed class WorkoutAnalyticsRepository : IWorkoutAnalyticsRepository
     public async Task<WorkoutLog?> GetWorkoutLogWithSetsAsync(
         int clientId, int workoutLogId, CancellationToken cancellationToken = default)
     {
-        return await _databaseContext.WorkoutLogs
+        return await databaseContext.WorkoutLogs
             .AsNoTracking()
             .Include(workoutLog => workoutLog.Exercises)
             .FirstOrDefaultAsync(workoutLog => workoutLog.WorkoutLogId == workoutLogId && workoutLog.Client.ClientId == clientId, cancellationToken);

--- a/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
+++ b/ClassLibrary/Repositories/WorkoutAnalyticsRepository.cs
@@ -10,42 +10,43 @@ using ClassLibrary.Data;
 using ClassLibrary.Models;
 using ClassLibrary.IRepositories;
 
-public sealed class WorkoutAnalyticsRepository(AppDbContext dbContext) : IWorkoutAnalyticsRepository
+public sealed class WorkoutAnalyticsRepository : IWorkoutAnalyticsRepository
 {
-    public async Task SaveWorkoutAsync(WorkoutLog log, CancellationToken cancellationToken = default)
+    private readonly AppDbContext _databaseContext;
+
+    public WorkoutAnalyticsRepository(AppDbContext databaseContext)
     {
-        await dbContext.WorkoutLogs.AddAsync(log, cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
+        _databaseContext = databaseContext;
+    }
+
+    public async Task SaveWorkoutAsync(WorkoutLog workoutLog, CancellationToken cancellationToken = default)
+    {
+        await _databaseContext.WorkoutLogs.AddAsync(workoutLog, cancellationToken);
+        await _databaseContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<int> GetTotalWorkoutsAsync(int clientId, CancellationToken cancellationToken = default)
     {
-        return await dbContext.WorkoutLogs
+        return await _databaseContext.WorkoutLogs
             .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
     }
 
     public async Task<IReadOnlyList<WorkoutLog>> GetWorkoutsInRangeAsync(
         int clientId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
     {
-        return await dbContext.WorkoutLogs
+        return await _databaseContext.WorkoutLogs
             .AsNoTracking()
             .Where(workoutLog => workoutLog.Client.ClientId == clientId && workoutLog.Date >= startDate && workoutLog.Date <= endDate)
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<int> GetTotalWorkoutCountAsync(int clientId, CancellationToken cancellationToken = default)
-    {
-        return await dbContext.WorkoutLogs
-            .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
-    }
-
-    public async Task<(IReadOnlyList<WorkoutLog> Items, int TotalCount)> GetWorkoutHistoryPageAsync(
+    public async Task<(IReadOnlyList<WorkoutLog> WorkoutLogs, int TotalCount)> GetWorkoutHistoryPageAsync(
         int clientId, int skip, int take, CancellationToken cancellationToken = default)
     {
-        var totalCount = await dbContext.WorkoutLogs
+        var totalCount = await _databaseContext.WorkoutLogs
             .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
 
-        var items = await dbContext.WorkoutLogs
+        var workoutLogs = await _databaseContext.WorkoutLogs
             .AsNoTracking()
             .Where(workoutLog => workoutLog.Client.ClientId == clientId)
             .OrderByDescending(workoutLog => workoutLog.Date)
@@ -54,13 +55,13 @@ public sealed class WorkoutAnalyticsRepository(AppDbContext dbContext) : IWorkou
             .Take(take)
             .ToListAsync(cancellationToken);
 
-        return (items, totalCount);
+        return (workoutLogs, totalCount);
     }
 
     public async Task<WorkoutLog?> GetWorkoutLogWithSetsAsync(
         int clientId, int workoutLogId, CancellationToken cancellationToken = default)
     {
-        return await dbContext.WorkoutLogs
+        return await _databaseContext.WorkoutLogs
             .AsNoTracking()
             .Include(workoutLog => workoutLog.Exercises)
             .FirstOrDefaultAsync(workoutLog => workoutLog.WorkoutLogId == workoutLogId && workoutLog.Client.ClientId == clientId, cancellationToken);


### PR DESCRIPTION
| File | Removed | Replacement Required |
|---|---|---|
| ShoppingListRepository.cs | `GetIngredientsNeededFromMealPlan` (Complex SQL doing mathematical business logic to calculate missing ingredients) | Move this math to a `ShoppingListService` that queries the MealPlan and Inventory repositories separately. |
| SqlWorkoutAnalyticsStore.cs | `EnsureCreatedAsync` method (raw SQL index creation) | Handled automatically by EF Core Code-First Migrations. |
| SqlWorkoutAnalyticsStore.cs | Proportional calorie math per exercise (`(totalCalories * setCount / totalSets)`) | An `AnalyticsService` must map the raw `WorkoutLog` entity to the `WorkoutSessionDetail` DTO and execute this math. |
| SqlWorkoutAnalyticsStore.cs | Date math for week buckets (`GetMondayOfWeek`, 4-week `for` loop, `AddDays(-6)`) | An `AnalyticsService` must calculate the `startDate` and `endDate` and pass them to the repo's new `GetWorkoutsInRangeAsync` method. |
| SqlWorkoutAnalyticsStore.cs | `ParseDurationToSeconds` (Manual string-to-TimeSpan parsing) | Removed. EF Core handles `TimeSpan` mapping to the database natively via the Entity model. |
| SqlWorkoutAnalyticsStore.cs | Pagination default logic (`if (pageIndex < 0) pageIndex = 0;`) | The Service or API Controller must validate pagination inputs and pass raw `skip`/`take` integers to the repository. |