### PR TITLE
feat: add NutritionSyncPayload and NutritionSyncOptions models

### DIFF
--- a/ClassLibrary/Models/NutritionSyncOptions.cs
+++ b/ClassLibrary/Models/NutritionSyncOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ClassLibrary.Models
+{
+    public class NutritionSyncOptions
+    {
+        private const string DefaultEndpoint = "http://localhost:5000/api/nutrition/sync";
+
+        public string Endpoint { get; set; } = DefaultEndpoint;
+    }
+}

--- a/ClassLibrary/Models/NutritionSyncPayload.cs
+++ b/ClassLibrary/Models/NutritionSyncPayload.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ClassLibrary.Models
+{
+    public class NutritionSyncPayload
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public int TotalCalories { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public string WorkoutDifficulty { get; set; } = string.Empty;
+
+        [Required]
+        [Range(0, 100)]
+        public float UserBmi { get; set; }
+    }
+}


### PR DESCRIPTION
Added NutritionSyncPayload and NutritionSyncOptions models.

 Converted NutritionSyncPayload into an EF Core entity using Data Annotations
 Removed JSON and integrationspecific logic
 Kept NutritionSyncOptions as a configuration model

No database changes were made as NutritionSyncPayload is intended for integration purposes!!!!