### PR TITLE
Integrate FoodItem and MealPlan services

### DIFF
--- a/ClassLibrary/DTOs/FoodItemDto.cs
+++ b/ClassLibrary/DTOs/FoodItemDto.cs
@@ -1,0 +1,30 @@
+namespace ClassLibrary.DTOs;
+
+public sealed class FoodItemDto
+{
+    public int FoodItemId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int Calories { get; set; }
+
+    public int Carbohydrates { get; set; }
+
+    public int Fat { get; set; }
+
+    public int Protein { get; set; }
+
+    public bool IsVegan { get; set; }
+
+    public bool IsKeto { get; set; }
+
+    public bool IsGlutenFree { get; set; }
+
+    public bool IsLactoseFree { get; set; }
+
+    public bool IsNutFree { get; set; }
+
+    public string Description { get; set; } = string.Empty;
+
+    public string ImageUrl { get; set; } = string.Empty;
+}

--- a/ClassLibrary/DTOs/MealPlanDto.cs
+++ b/ClassLibrary/DTOs/MealPlanDto.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace ClassLibrary.DTOs;
+
+public sealed class MealPlanDto
+{
+    public int MealPlanId { get; set; }
+
+    public int UserId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public string GoalType { get; set; } = string.Empty;
+
+    public List<FoodItemDto> FoodItems { get; set; } = new();
+}

--- a/WebAPI/Controllers/FoodItemsController.cs
+++ b/WebAPI/Controllers/FoodItemsController.cs
@@ -1,0 +1,44 @@
+using ClassLibrary.Models;
+using Microsoft.AspNetCore.Mvc;
+using WebAPI.Services;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class FoodItemsController : ControllerBase
+{
+    private readonly IFoodItemService foodItemService;
+
+    public FoodItemsController(IFoodItemService foodItemService)
+    {
+        this.foodItemService = foodItemService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+    {
+        var foodItems = await this.foodItemService.GetAllAsync(cancellationToken);
+        return this.Ok(foodItems);
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetById(int id, CancellationToken cancellationToken)
+    {
+        var foodItem = await this.foodItemService.GetByIdAsync(id, cancellationToken);
+
+        if (foodItem is null)
+        {
+            return this.NotFound();
+        }
+
+        return this.Ok(foodItem);
+    }
+
+    [HttpGet("filter")]
+    public async Task<IActionResult> GetFiltered([FromQuery] FoodItemFilter filter, CancellationToken cancellationToken)
+    {
+        var foodItems = await this.foodItemService.GetFilteredAsync(filter, cancellationToken);
+        return this.Ok(foodItems);
+    }
+}

--- a/WebAPI/Controllers/MealPlansController.cs
+++ b/WebAPI/Controllers/MealPlansController.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+using WebAPI.Services;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class MealPlansController : ControllerBase
+{
+    private readonly IMealPlanService mealPlanService;
+
+    public MealPlansController(IMealPlanService mealPlanService)
+    {
+        this.mealPlanService = mealPlanService;
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetById(int id, CancellationToken cancellationToken)
+    {
+        var mealPlan = await this.mealPlanService.GetByIdAsync(id, cancellationToken);
+
+        if (mealPlan is null)
+        {
+            return this.NotFound();
+        }
+
+        return this.Ok(mealPlan);
+    }
+
+    [HttpGet("user/{userId:int}")]
+    public async Task<IActionResult> GetByUserId(int userId, CancellationToken cancellationToken)
+    {
+        var mealPlans = await this.mealPlanService.GetByUserIdAsync(userId, cancellationToken);
+        return this.Ok(mealPlans);
+    }
+
+    [HttpPost("{mealPlanId:int}/fooditems/{foodItemId:int}")]
+    public async Task<IActionResult> AddFoodItem(int mealPlanId, int foodItemId, CancellationToken cancellationToken)
+    {
+        await this.mealPlanService.AddFoodItemToPlanAsync(mealPlanId, foodItemId, cancellationToken);
+        return this.NoContent();
+    }
+
+    [HttpDelete("{mealPlanId:int}/fooditems/{foodItemId:int}")]
+    public async Task<IActionResult> RemoveFoodItem(int mealPlanId, int foodItemId, CancellationToken cancellationToken)
+    {
+        await this.mealPlanService.RemoveFoodItemFromPlanAsync(mealPlanId, foodItemId, cancellationToken);
+        return this.NoContent();
+    }
+
+    [HttpGet("{mealPlanId:int}/fooditems")]
+    public async Task<IActionResult> GetFoodItems(int mealPlanId, CancellationToken cancellationToken)
+    {
+        var foodItems = await this.mealPlanService.GetFoodItemsForPlanAsync(mealPlanId, cancellationToken);
+        return this.Ok(foodItems);
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddWebApiServices(this IServiceCollection services)
     {
         services.AddScoped<IUserService, UserService>();
+        services.AddScoped<IFoodItemService, FoodItemService>();
         return services;
     }
 }

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<IFoodItemService, FoodItemService>();
+        services.AddScoped<IMealPlanService, MealPlanService>();
         return services;
     }
 }

--- a/WebAPI/Services/FoodItemService.cs
+++ b/WebAPI/Services/FoodItemService.cs
@@ -1,0 +1,58 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+
+namespace WebAPI.Services;
+
+public sealed class FoodItemService : IFoodItemService
+{
+    private readonly IFoodItemRepository foodItemRepository;
+
+    public FoodItemService(IFoodItemRepository foodItemRepository)
+    {
+        this.foodItemRepository = foodItemRepository;
+    }
+
+    public async Task<IReadOnlyList<FoodItemDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var foodItems = await this.foodItemRepository.GetAllAsync(cancellationToken);
+        return MapToDtos(foodItems);
+    }
+
+    public async Task<FoodItemDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var foodItem = await this.foodItemRepository.GetByIdAsync(id, cancellationToken);
+        return foodItem is null ? null : MapToDto(foodItem);
+    }
+
+    public async Task<IReadOnlyList<FoodItemDto>> GetFilteredAsync(FoodItemFilter filter, CancellationToken cancellationToken = default)
+    {
+        var foodItems = await this.foodItemRepository.GetByFilterAsync(filter, cancellationToken);
+        return MapToDtos(foodItems);
+    }
+
+    private static FoodItemDto MapToDto(FoodItem foodItem)
+    {
+        return new FoodItemDto
+        {
+            FoodItemId = foodItem.FoodItemId,
+            Name = foodItem.Name,
+            Calories = foodItem.Calories,
+            Carbohydrates = foodItem.Carbohydrates,
+            Fat = foodItem.Fat,
+            Protein = foodItem.Protein,
+            IsVegan = foodItem.IsVegan,
+            IsKeto = foodItem.IsKeto,
+            IsGlutenFree = foodItem.IsGlutenFree,
+            IsLactoseFree = foodItem.IsLactoseFree,
+            IsNutFree = foodItem.IsNutFree,
+            Description = foodItem.Description,
+            ImageUrl = foodItem.ImageUrl,
+        };
+    }
+
+    private static IReadOnlyList<FoodItemDto> MapToDtos(IReadOnlyList<FoodItem> foodItems)
+    {
+        return foodItems.Select(MapToDto).ToList();
+    }
+}

--- a/WebAPI/Services/IFoodItemService.cs
+++ b/WebAPI/Services/IFoodItemService.cs
@@ -1,0 +1,13 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.Models;
+
+namespace WebAPI.Services;
+
+public interface IFoodItemService
+{
+    Task<IReadOnlyList<FoodItemDto>> GetAllAsync(CancellationToken cancellationToken = default);
+
+    Task<FoodItemDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FoodItemDto>> GetFilteredAsync(FoodItemFilter filter, CancellationToken cancellationToken = default);
+}

--- a/WebAPI/Services/IMealPlanService.cs
+++ b/WebAPI/Services/IMealPlanService.cs
@@ -13,4 +13,8 @@ public interface IMealPlanService
     Task RemoveFoodItemFromPlanAsync(int mealPlanId, int foodItemId, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<FoodItemDto>> GetFoodItemsForPlanAsync(int mealPlanId, CancellationToken cancellationToken = default);
+
+    (int TotalCalories, int TotalProtein, int TotalCarbohydrates, int TotalFat) CalculateTotalNutrition(IReadOnlyList<FoodItemDto> foodItems);
+
+    bool ValidateMealPlan(IReadOnlyList<FoodItemDto> foodItems, int targetCalories, int targetProtein, int targetCarbohydrates, int targetFat, double tolerance = 0.10);
 }

--- a/WebAPI/Services/IMealPlanService.cs
+++ b/WebAPI/Services/IMealPlanService.cs
@@ -1,0 +1,16 @@
+using ClassLibrary.DTOs;
+
+namespace WebAPI.Services;
+
+public interface IMealPlanService
+{
+    Task<MealPlanDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<MealPlanDto>> GetByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task AddFoodItemToPlanAsync(int mealPlanId, int foodItemId, CancellationToken cancellationToken = default);
+
+    Task RemoveFoodItemFromPlanAsync(int mealPlanId, int foodItemId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FoodItemDto>> GetFoodItemsForPlanAsync(int mealPlanId, CancellationToken cancellationToken = default);
+}

--- a/WebAPI/Services/MealPlanService.cs
+++ b/WebAPI/Services/MealPlanService.cs
@@ -1,6 +1,7 @@
 using System;
 using ClassLibrary.DTOs;
 using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
 
 namespace WebAPI.Services;
 
@@ -26,29 +27,7 @@ public sealed class MealPlanService : IMealPlanService
 
         var foodItems = await this.mealPlanRepository.GetFoodItemsForPlanAsync(id, cancellationToken);
 
-        return new MealPlanDto
-        {
-            MealPlanId = mealPlan.MealPlanId,
-            UserId = mealPlan.UserId,
-            CreatedAt = mealPlan.CreatedAt,
-            GoalType = mealPlan.GoalType,
-            FoodItems = foodItems.Select(foodItem => new FoodItemDto
-            {
-                FoodItemId = foodItem.FoodItemId,
-                Name = foodItem.Name,
-                Calories = foodItem.Calories,
-                Carbohydrates = foodItem.Carbohydrates,
-                Fat = foodItem.Fat,
-                Protein = foodItem.Protein,
-                IsVegan = foodItem.IsVegan,
-                IsKeto = foodItem.IsKeto,
-                IsGlutenFree = foodItem.IsGlutenFree,
-                IsLactoseFree = foodItem.IsLactoseFree,
-                IsNutFree = foodItem.IsNutFree,
-                Description = foodItem.Description,
-                ImageUrl = foodItem.ImageUrl,
-            }).ToList(),
-        };
+        return MapToMealPlanDto(mealPlan, foodItems);
     }
 
     public async Task<IReadOnlyList<MealPlanDto>> GetByUserIdAsync(int userId, CancellationToken cancellationToken = default)
@@ -59,30 +38,7 @@ public sealed class MealPlanService : IMealPlanService
         foreach (var mealPlan in mealPlans)
         {
             var foodItems = await this.mealPlanRepository.GetFoodItemsForPlanAsync(mealPlan.MealPlanId, cancellationToken);
-
-            results.Add(new MealPlanDto
-            {
-                MealPlanId = mealPlan.MealPlanId,
-                UserId = mealPlan.UserId,
-                CreatedAt = mealPlan.CreatedAt,
-                GoalType = mealPlan.GoalType,
-                FoodItems = foodItems.Select(foodItem => new FoodItemDto
-                {
-                    FoodItemId = foodItem.FoodItemId,
-                    Name = foodItem.Name,
-                    Calories = foodItem.Calories,
-                    Carbohydrates = foodItem.Carbohydrates,
-                    Fat = foodItem.Fat,
-                    Protein = foodItem.Protein,
-                    IsVegan = foodItem.IsVegan,
-                    IsKeto = foodItem.IsKeto,
-                    IsGlutenFree = foodItem.IsGlutenFree,
-                    IsLactoseFree = foodItem.IsLactoseFree,
-                    IsNutFree = foodItem.IsNutFree,
-                    Description = foodItem.Description,
-                    ImageUrl = foodItem.ImageUrl,
-                }).ToList(),
-            });
+            results.Add(MapToMealPlanDto(mealPlan, foodItems));
         }
 
         return results;
@@ -101,23 +57,7 @@ public sealed class MealPlanService : IMealPlanService
     public async Task<IReadOnlyList<FoodItemDto>> GetFoodItemsForPlanAsync(int mealPlanId, CancellationToken cancellationToken = default)
     {
         var foodItems = await this.mealPlanRepository.GetFoodItemsForPlanAsync(mealPlanId, cancellationToken);
-
-        return foodItems.Select(foodItem => new FoodItemDto
-        {
-            FoodItemId = foodItem.FoodItemId,
-            Name = foodItem.Name,
-            Calories = foodItem.Calories,
-            Carbohydrates = foodItem.Carbohydrates,
-            Fat = foodItem.Fat,
-            Protein = foodItem.Protein,
-            IsVegan = foodItem.IsVegan,
-            IsKeto = foodItem.IsKeto,
-            IsGlutenFree = foodItem.IsGlutenFree,
-            IsLactoseFree = foodItem.IsLactoseFree,
-            IsNutFree = foodItem.IsNutFree,
-            Description = foodItem.Description,
-            ImageUrl = foodItem.ImageUrl,
-        }).ToList();
+        return MapToFoodItemDtos(foodItems);
     }
 
     public (int TotalCalories, int TotalProtein, int TotalCarbohydrates, int TotalFat) CalculateTotalNutrition(IReadOnlyList<FoodItemDto> foodItems)
@@ -149,5 +89,42 @@ public sealed class MealPlanService : IMealPlanService
             Math.Abs(totalProtein - targetProtein) <= targetProtein * tolerance &&
             Math.Abs(totalCarbohydrates - targetCarbohydrates) <= targetCarbohydrates * tolerance &&
             Math.Abs(totalFat - targetFat) <= targetFat * tolerance;
+    }
+
+    private static FoodItemDto MapToFoodItemDto(FoodItem foodItem)
+    {
+        return new FoodItemDto
+        {
+            FoodItemId = foodItem.FoodItemId,
+            Name = foodItem.Name,
+            Calories = foodItem.Calories,
+            Carbohydrates = foodItem.Carbohydrates,
+            Fat = foodItem.Fat,
+            Protein = foodItem.Protein,
+            IsVegan = foodItem.IsVegan,
+            IsKeto = foodItem.IsKeto,
+            IsGlutenFree = foodItem.IsGlutenFree,
+            IsLactoseFree = foodItem.IsLactoseFree,
+            IsNutFree = foodItem.IsNutFree,
+            Description = foodItem.Description,
+            ImageUrl = foodItem.ImageUrl,
+        };
+    }
+
+    private static List<FoodItemDto> MapToFoodItemDtos(IReadOnlyList<FoodItem> foodItems)
+    {
+        return foodItems.Select(MapToFoodItemDto).ToList();
+    }
+
+    private static MealPlanDto MapToMealPlanDto(MealPlan mealPlan, IReadOnlyList<FoodItem> foodItems)
+    {
+        return new MealPlanDto
+        {
+            MealPlanId = mealPlan.MealPlanId,
+            UserId = mealPlan.UserId,
+            CreatedAt = mealPlan.CreatedAt,
+            GoalType = mealPlan.GoalType,
+            FoodItems = MapToFoodItemDtos(foodItems),
+        };
     }
 }

--- a/WebAPI/Services/MealPlanService.cs
+++ b/WebAPI/Services/MealPlanService.cs
@@ -1,0 +1,153 @@
+using System;
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+
+namespace WebAPI.Services;
+
+public sealed class MealPlanService : IMealPlanService
+{
+    private const double DEFAULT_TOLERANCE = 0.10;
+
+    private readonly IMealPlanRepository mealPlanRepository;
+
+    public MealPlanService(IMealPlanRepository mealPlanRepository)
+    {
+        this.mealPlanRepository = mealPlanRepository;
+    }
+
+    public async Task<MealPlanDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var mealPlan = await this.mealPlanRepository.GetByIdAsync(id, cancellationToken);
+
+        if (mealPlan is null)
+        {
+            return null;
+        }
+
+        var foodItems = await this.mealPlanRepository.GetFoodItemsForPlanAsync(id, cancellationToken);
+
+        return new MealPlanDto
+        {
+            MealPlanId = mealPlan.MealPlanId,
+            UserId = mealPlan.UserId,
+            CreatedAt = mealPlan.CreatedAt,
+            GoalType = mealPlan.GoalType,
+            FoodItems = foodItems.Select(foodItem => new FoodItemDto
+            {
+                FoodItemId = foodItem.FoodItemId,
+                Name = foodItem.Name,
+                Calories = foodItem.Calories,
+                Carbohydrates = foodItem.Carbohydrates,
+                Fat = foodItem.Fat,
+                Protein = foodItem.Protein,
+                IsVegan = foodItem.IsVegan,
+                IsKeto = foodItem.IsKeto,
+                IsGlutenFree = foodItem.IsGlutenFree,
+                IsLactoseFree = foodItem.IsLactoseFree,
+                IsNutFree = foodItem.IsNutFree,
+                Description = foodItem.Description,
+                ImageUrl = foodItem.ImageUrl,
+            }).ToList(),
+        };
+    }
+
+    public async Task<IReadOnlyList<MealPlanDto>> GetByUserIdAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var mealPlans = await this.mealPlanRepository.GetByUserIdAsync(userId, cancellationToken);
+
+        var results = new List<MealPlanDto>(mealPlans.Count);
+        foreach (var mealPlan in mealPlans)
+        {
+            var foodItems = await this.mealPlanRepository.GetFoodItemsForPlanAsync(mealPlan.MealPlanId, cancellationToken);
+
+            results.Add(new MealPlanDto
+            {
+                MealPlanId = mealPlan.MealPlanId,
+                UserId = mealPlan.UserId,
+                CreatedAt = mealPlan.CreatedAt,
+                GoalType = mealPlan.GoalType,
+                FoodItems = foodItems.Select(foodItem => new FoodItemDto
+                {
+                    FoodItemId = foodItem.FoodItemId,
+                    Name = foodItem.Name,
+                    Calories = foodItem.Calories,
+                    Carbohydrates = foodItem.Carbohydrates,
+                    Fat = foodItem.Fat,
+                    Protein = foodItem.Protein,
+                    IsVegan = foodItem.IsVegan,
+                    IsKeto = foodItem.IsKeto,
+                    IsGlutenFree = foodItem.IsGlutenFree,
+                    IsLactoseFree = foodItem.IsLactoseFree,
+                    IsNutFree = foodItem.IsNutFree,
+                    Description = foodItem.Description,
+                    ImageUrl = foodItem.ImageUrl,
+                }).ToList(),
+            });
+        }
+
+        return results;
+    }
+
+    public async Task AddFoodItemToPlanAsync(int mealPlanId, int foodItemId, CancellationToken cancellationToken = default)
+    {
+        await this.mealPlanRepository.AddFoodItemToPlanAsync(mealPlanId, foodItemId, cancellationToken);
+    }
+
+    public async Task RemoveFoodItemFromPlanAsync(int mealPlanId, int foodItemId, CancellationToken cancellationToken = default)
+    {
+        await this.mealPlanRepository.RemoveFoodItemFromPlanAsync(mealPlanId, foodItemId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<FoodItemDto>> GetFoodItemsForPlanAsync(int mealPlanId, CancellationToken cancellationToken = default)
+    {
+        var foodItems = await this.mealPlanRepository.GetFoodItemsForPlanAsync(mealPlanId, cancellationToken);
+
+        return foodItems.Select(foodItem => new FoodItemDto
+        {
+            FoodItemId = foodItem.FoodItemId,
+            Name = foodItem.Name,
+            Calories = foodItem.Calories,
+            Carbohydrates = foodItem.Carbohydrates,
+            Fat = foodItem.Fat,
+            Protein = foodItem.Protein,
+            IsVegan = foodItem.IsVegan,
+            IsKeto = foodItem.IsKeto,
+            IsGlutenFree = foodItem.IsGlutenFree,
+            IsLactoseFree = foodItem.IsLactoseFree,
+            IsNutFree = foodItem.IsNutFree,
+            Description = foodItem.Description,
+            ImageUrl = foodItem.ImageUrl,
+        }).ToList();
+    }
+
+    public (int TotalCalories, int TotalProtein, int TotalCarbohydrates, int TotalFat) CalculateTotalNutrition(IReadOnlyList<FoodItemDto> foodItems)
+    {
+        if (foodItems is null || foodItems.Count == 0)
+        {
+            return (0, 0, 0, 0);
+        }
+
+        int calories = 0, protein = 0, carbohydrates = 0, fat = 0;
+
+        foreach (var foodItem in foodItems)
+        {
+            calories += foodItem.Calories;
+            protein += foodItem.Protein;
+            carbohydrates += foodItem.Carbohydrates;
+            fat += foodItem.Fat;
+        }
+
+        return (calories, protein, carbohydrates, fat);
+    }
+
+    public bool ValidateMealPlan(IReadOnlyList<FoodItemDto> foodItems, int targetCalories, int targetProtein, int targetCarbohydrates, int targetFat, double tolerance = DEFAULT_TOLERANCE)
+    {
+        var (totalCalories, totalProtein, totalCarbohydrates, totalFat) = CalculateTotalNutrition(foodItems);
+
+        return
+            Math.Abs(totalCalories - targetCalories) <= targetCalories * tolerance &&
+            Math.Abs(totalProtein - targetProtein) <= targetProtein * tolerance &&
+            Math.Abs(totalCarbohydrates - targetCarbohydrates) <= targetCarbohydrates * tolerance &&
+            Math.Abs(totalFat - targetFat) <= targetFat * tolerance;
+    }
+}


### PR DESCRIPTION
Closes #89, closes #90

Added service layer and REST controllers for FoodItem and MealPlan, building on top of the repositories we already have in main.

**What's included:**
- `FoodItemDto` and `MealPlanDto` for the API responses
- `IFoodItemService` / `FoodItemService` -- get all, get by id, filter by dietary preferences
- `IMealPlanService` / `MealPlanService` -- get plans, add/remove food items from a plan, nutrition totals and validation
- `FoodItemsController` and `MealPlansController` with standard REST endpoints
- DI registration in `ServiceCollectionExtensions`

**Deferred / out of scope:**
- `IsFavorite` is intentionally left out of `FoodItemDto` since favorite status is per-user and should live in a dedicated favorites endpoint, not baked into every food item response
- Personalized meal plan generation, reminder integration, and daily log saving are deferred since the underlying repository methods aren't available yet
- `ToggleFavoriteAsync` and `GetMealIngredientLinesAsync` from the original NUT MealService are also deferred for the same reason

**Note:** The original NUT project used `Meal` which was renamed to `FoodItem` during the models integration, so `MealService` became `FoodItemService` here.