### PR TITLE
Fix Notification and WorkoutLog models

### DIFF
--- a/ClassLibrary/Models/Notification.cs
+++ b/ClassLibrary/Models/Notification.cs
@@ -14,7 +14,8 @@ public class Notification
 {
     public int NotificationId { get; set; }
 
-    [Required]
+    public int ClientId { get; set; }
+
     public Client Client { get; set; } = null!;
 
     [Required]
@@ -25,14 +26,11 @@ public class Notification
     [MaxLength(1000)]
     public string Message { get; set; } = string.Empty;
 
-    [Required]
     public NotificationType Type { get; set; }
 
     public int RelatedId { get; set; }
 
-    [Required]
     public DateTime DateCreated { get; set; }
 
-    [Required]
     public bool IsRead { get; set; }
 }

--- a/ClassLibrary/Models/WorkoutLog.cs
+++ b/ClassLibrary/Models/WorkoutLog.cs
@@ -6,22 +6,20 @@ public sealed class WorkoutLog
 {
     public int WorkoutLogId { get; set; }
 
-    [Required]
+    public int ClientId { get; set; }
+
     public Client Client { get; set; } = null!;
 
     [Required]
     [MaxLength(200)]
     public string WorkoutName { get; set; } = string.Empty;
 
-    [Required]
     public DateTime Date { get; set; }
 
-    [Required]
     public TimeSpan Duration { get; set; }
 
-    public int SourceTemplateId { get; set; }
+    public int? SourceTemplateId { get; set; }
 
-    [Required]
     public WorkoutType Type { get; set; }
 
     public List<LoggedExercise> Exercises { get; set; } = new();

--- a/ClassLibrary/Repositories/RepositoryAchievements.cs
+++ b/ClassLibrary/Repositories/RepositoryAchievements.cs
@@ -26,13 +26,13 @@ public sealed class RepositoryAchievements : IRepositoryAchievements
     public async Task<int> GetWorkoutCountAsync(int clientId, CancellationToken cancellationToken = default)
     {
         return await this.databaseContext.WorkoutLogs
-            .CountAsync(workoutLog => workoutLog.Client.ClientId == clientId, cancellationToken);
+            .CountAsync(workoutLog => workoutLog.ClientId == clientId, cancellationToken);
     }
 
     public async Task<int> GetDistinctWorkoutDayCountAsync(int clientId, CancellationToken cancellationToken = default)
     {
         return await this.databaseContext.WorkoutLogs
-            .Where(workoutLog => workoutLog.Client.ClientId == clientId)
+            .Where(workoutLog => workoutLog.ClientId == clientId)
             .Select(workoutLog => workoutLog.Date.Date)
             .Distinct()
             .CountAsync(cancellationToken);
@@ -46,14 +46,14 @@ public sealed class RepositoryAchievements : IRepositoryAchievements
 
         return await this.databaseContext.WorkoutLogs
             .CountAsync(
-                workoutLog => workoutLog.Client.ClientId == clientId && workoutLog.Date >= cutoff && workoutLog.Date < tomorrow,
+                workoutLog => workoutLog.ClientId == clientId && workoutLog.Date >= cutoff && workoutLog.Date < tomorrow,
                 cancellationToken);
     }
 
     public async Task<int> GetConsecutiveWorkoutDayStreakAsync(int clientId, CancellationToken cancellationToken = default)
     {
         var dates = await this.databaseContext.WorkoutLogs
-            .Where(workoutLog => workoutLog.Client.ClientId == clientId)
+            .Where(workoutLog => workoutLog.ClientId == clientId)
             .Select(workoutLog => workoutLog.Date.Date)
             .Distinct()
             .OrderByDescending(date => date)

--- a/ClassLibrary/Repositories/RepositoryNotification.cs
+++ b/ClassLibrary/Repositories/RepositoryNotification.cs
@@ -18,7 +18,7 @@ public sealed class RepositoryNotification : IRepositoryNotification
     {
         return await this.databaseContext.Notifications
             .AsNoTracking()
-            .Where(notification => notification.Client.ClientId == clientId)
+            .Where(notification => notification.ClientId == clientId)
             .OrderByDescending(notification => notification.DateCreated)
             .ToListAsync(cancellationToken);
     }


### PR DESCRIPTION
Added missing foreign key (ClientId) to Notification and WorkoutLog models, and removed unnecessary validation attributes from non-nullable fields. Updated the repositories to use the new foreign key directly instead of navigating through the Client object.

---------------------------------------------------------------------------------------------
Related to the message from Whatsapp, on Group Swe nut + videcoders:
"These models have problems
Favorite, FoodItemIngredient, Inventory, MealPlan, MealPlanFoodItem, FoodItemFilter,
Notification, TemplateExercise, UserData, WorkoutLog, WorkoutTemplate
whichever one of you knows they did this please fix, fixes includes:

User data has logic
Itemfilter doesnt make sense to be a db entity

The rest have foreignkey ids instead of just referencing clases"