### PR TITLE
Fix model issues: extract UserData logic, move FoodItemFilter

### DIFF
--- a/ClassLibrary/Filters/FoodItemFilter.cs
+++ b/ClassLibrary/Filters/FoodItemFilter.cs
@@ -1,4 +1,4 @@
-namespace ClassLibrary.Models;
+namespace ClassLibrary.Filters;
 
 public sealed class FoodItemFilter
 {

--- a/ClassLibrary/IRepositories/IFoodItemRepository.cs
+++ b/ClassLibrary/IRepositories/IFoodItemRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using ClassLibrary.Filters;
 using ClassLibrary.Models;
 
 namespace ClassLibrary.IRepositories;

--- a/ClassLibrary/Models/UserData.cs
+++ b/ClassLibrary/Models/UserData.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace ClassLibrary.Models;
@@ -15,32 +14,8 @@ public sealed class UserData
     private const string ERROR_GOAL_REQUIRED = "Please select a goal";
     private const string ERROR_GENDER_INVALID = "Gender must be 'male' or 'female'";
     private const string ERROR_GOAL_INVALID = "Select a valid goal";
-    private const string GENDER_MALE = "male";
-    private const string GENDER_FEMALE = "female";
-    private const string GOAL_BULK = "bulk";
-    private const string GOAL_CUT = "cut";
-    private const string GOAL_MAINTENANCE = "maintenance";
-    private const string GOAL_WELL_BEING = "well-being";
     private const string REGEX_GENDER = @"^(male|female)$";
     private const string REGEX_GOAL = @"^(bulk|cut|maintenance|well-being)$";
-    private const double BASAL_METABOLIC_RATE_WEIGHT_FACTOR = 10.0;
-    private const double BASAL_METABOLIC_RATE_HEIGHT_FACTOR = 6.25;
-    private const double BASAL_METABOLIC_RATE_AGE_FACTOR = 5.0;
-    private const double BASAL_METABOLIC_RATE_MALE_OFFSET = 5.0;
-    private const double BASAL_METABOLIC_RATE_FEMALE_OFFSET = 161.0;
-    private const double ACTIVITY_MULTIPLIER = 1.55;
-    private const int BULK_CALORIE_DELTA = 300;
-    private const int CUT_CALORIE_DELTA = -300;
-    private const double PROTEIN_BULK = 2.0;
-    private const double PROTEIN_CUT = 2.2;
-    private const double PROTEIN_MAINTENANCE = 1.8;
-    private const double PROTEIN_WELL_BEING = 1.6;
-    private const double FAT_BULK_CUT = 0.25;
-    private const double FAT_MAINTENANCE = 0.28;
-    private const double FAT_WELL_BEING = 0.30;
-    private const int CALORIES_PER_GRAM_PROTEIN = 4;
-    private const int CALORIES_PER_GRAM_CARBOHYDRATES = 4;
-    private const int CALORIES_PER_GRAM_FAT = 9;
 
     public int UserDataId { get; set; }
 
@@ -73,129 +48,4 @@ public sealed class UserData
     public int CarbohydrateNeeds { get; set; }
 
     public int FatNeeds { get; set; }
-
-    public int CalculateAge(DateTimeOffset? birthDate)
-    {
-        if (birthDate == null)
-        {
-            return 0;
-        }
-
-        var today = DateTime.Today;
-        var birth = birthDate.Value.DateTime;
-
-        int age = today.Year - birth.Year;
-        if (birth.Date > today.AddYears(-age))
-        {
-            age--;
-        }
-
-        return age;
-    }
-
-    public double CalculateBodyMassIndex()
-    {
-        if (Height <= 0 || Weight <= 0)
-        {
-            return 0;
-        }
-
-        double heightMeters = Height / 100.0;
-        double bodyMassIndex = Weight / (heightMeters * heightMeters);
-
-        return (int)Math.Round(bodyMassIndex);
-    }
-
-    public int CalculateCalorieNeeds()
-    {
-        if (Weight <= 0 || Height <= 0 || Age <= 0)
-        {
-            return 0;
-        }
-
-        double basalMetabolicRate =
-            Gender.Equals(GENDER_MALE, StringComparison.OrdinalIgnoreCase)
-                ? (BASAL_METABOLIC_RATE_WEIGHT_FACTOR * Weight) +
-                  (BASAL_METABOLIC_RATE_HEIGHT_FACTOR * Height) -
-                  (BASAL_METABOLIC_RATE_AGE_FACTOR * Age) +
-                  BASAL_METABOLIC_RATE_MALE_OFFSET
-                : Gender.Equals(GENDER_FEMALE, StringComparison.OrdinalIgnoreCase)
-                    ? (BASAL_METABOLIC_RATE_WEIGHT_FACTOR * Weight) +
-                      (BASAL_METABOLIC_RATE_HEIGHT_FACTOR * Height) -
-                      (BASAL_METABOLIC_RATE_AGE_FACTOR * Age) -
-                      BASAL_METABOLIC_RATE_FEMALE_OFFSET
-                    : 0;
-
-        if (basalMetabolicRate <= 0)
-        {
-            return 0;
-        }
-
-        double totalDailyEnergyExpenditure = basalMetabolicRate * ACTIVITY_MULTIPLIER;
-
-        double adjustedCalories = Goal.ToLower() switch
-        {
-            GOAL_BULK => totalDailyEnergyExpenditure + BULK_CALORIE_DELTA,
-            GOAL_CUT => totalDailyEnergyExpenditure + CUT_CALORIE_DELTA,
-            GOAL_MAINTENANCE => totalDailyEnergyExpenditure,
-            GOAL_WELL_BEING => totalDailyEnergyExpenditure,
-            _ => totalDailyEnergyExpenditure
-        };
-
-        return (int)Math.Round(adjustedCalories);
-    }
-
-    public int CalculateProteinNeeds()
-    {
-        if (Weight <= 0)
-        {
-            return 0;
-        }
-
-        double proteinPerKg = Goal.ToLower() switch
-        {
-            GOAL_BULK => PROTEIN_BULK,
-            GOAL_CUT => PROTEIN_CUT,
-            GOAL_MAINTENANCE => PROTEIN_MAINTENANCE,
-            GOAL_WELL_BEING => PROTEIN_WELL_BEING,
-            _ => PROTEIN_MAINTENANCE
-        };
-
-        return (int)Math.Round(Weight * proteinPerKg);
-    }
-
-    public int CalculateFatNeeds()
-    {
-        int calories = CalculateCalorieNeeds();
-        if (calories <= 0)
-        {
-            return 0;
-        }
-
-        double fatRatio = Goal.ToLower() switch
-        {
-            GOAL_BULK or GOAL_CUT => FAT_BULK_CUT,
-            GOAL_MAINTENANCE => FAT_MAINTENANCE,
-            GOAL_WELL_BEING => FAT_WELL_BEING,
-            _ => FAT_BULK_CUT
-        };
-
-        double fatCalories = calories * fatRatio;
-        return (int)Math.Round(fatCalories / CALORIES_PER_GRAM_FAT);
-    }
-
-    public int CalculateCarbohydrateNeeds()
-    {
-        int calories = CalculateCalorieNeeds();
-        int proteinCalories = CalculateProteinNeeds() * CALORIES_PER_GRAM_PROTEIN;
-        int fatCalories = CalculateFatNeeds() * CALORIES_PER_GRAM_FAT;
-
-        if (calories <= 0)
-        {
-            return 0;
-        }
-
-        int carbohydrateCalories = Math.Max(0, calories - proteinCalories - fatCalories);
-        return (int)Math.Round(carbohydrateCalories / (double)CALORIES_PER_GRAM_CARBOHYDRATES);
-    }
 }

--- a/ClassLibrary/Repositories/FoodItemRepository.cs
+++ b/ClassLibrary/Repositories/FoodItemRepository.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ClassLibrary.Data;
+using ClassLibrary.Filters;
 using ClassLibrary.IRepositories;
 using ClassLibrary.Models;
 using Microsoft.EntityFrameworkCore;

--- a/ClassLibrary/Services/NutritionCalculator.cs
+++ b/ClassLibrary/Services/NutritionCalculator.cs
@@ -37,11 +37,11 @@ public static class NutritionCalculator
             return 0;
         }
 
-        var today = DateTime.Today;
-        var birth = birthDate.Value.DateTime;
+        var today = DateOnly.FromDateTime(DateTime.Today);
+        var birth = DateOnly.FromDateTime(birthDate.Value.Date);
 
         int age = today.Year - birth.Year;
-        if (birth.Date > today.AddYears(-age))
+        if (birth > today.AddYears(-age))
         {
             age--;
         }
@@ -59,7 +59,7 @@ public static class NutritionCalculator
         double heightMeters = userData.Height / 100.0;
         double bodyMassIndex = userData.Weight / (heightMeters * heightMeters);
 
-        return (int)Math.Round(bodyMassIndex);
+        return Math.Round(bodyMassIndex);
     }
 
     public static int CalculateCalorieNeeds(UserData userData)

--- a/ClassLibrary/Services/NutritionCalculator.cs
+++ b/ClassLibrary/Services/NutritionCalculator.cs
@@ -1,0 +1,157 @@
+using System;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.Services;
+
+public static class NutritionCalculator
+{
+    private const string GENDER_MALE = "male";
+    private const string GENDER_FEMALE = "female";
+    private const string GOAL_BULK = "bulk";
+    private const string GOAL_CUT = "cut";
+    private const string GOAL_MAINTENANCE = "maintenance";
+    private const string GOAL_WELL_BEING = "well-being";
+    private const double BASAL_METABOLIC_RATE_WEIGHT_FACTOR = 10.0;
+    private const double BASAL_METABOLIC_RATE_HEIGHT_FACTOR = 6.25;
+    private const double BASAL_METABOLIC_RATE_AGE_FACTOR = 5.0;
+    private const double BASAL_METABOLIC_RATE_MALE_OFFSET = 5.0;
+    private const double BASAL_METABOLIC_RATE_FEMALE_OFFSET = 161.0;
+    private const double ACTIVITY_MULTIPLIER = 1.55;
+    private const int BULK_CALORIE_DELTA = 300;
+    private const int CUT_CALORIE_DELTA = -300;
+    private const double PROTEIN_BULK = 2.0;
+    private const double PROTEIN_CUT = 2.2;
+    private const double PROTEIN_MAINTENANCE = 1.8;
+    private const double PROTEIN_WELL_BEING = 1.6;
+    private const double FAT_BULK_CUT = 0.25;
+    private const double FAT_MAINTENANCE = 0.28;
+    private const double FAT_WELL_BEING = 0.30;
+    private const int CALORIES_PER_GRAM_PROTEIN = 4;
+    private const int CALORIES_PER_GRAM_CARBOHYDRATES = 4;
+    private const int CALORIES_PER_GRAM_FAT = 9;
+
+    public static int CalculateAge(DateTimeOffset? birthDate)
+    {
+        if (birthDate == null)
+        {
+            return 0;
+        }
+
+        var today = DateTime.Today;
+        var birth = birthDate.Value.DateTime;
+
+        int age = today.Year - birth.Year;
+        if (birth.Date > today.AddYears(-age))
+        {
+            age--;
+        }
+
+        return age;
+    }
+
+    public static double CalculateBodyMassIndex(UserData userData)
+    {
+        if (userData.Height <= 0 || userData.Weight <= 0)
+        {
+            return 0;
+        }
+
+        double heightMeters = userData.Height / 100.0;
+        double bodyMassIndex = userData.Weight / (heightMeters * heightMeters);
+
+        return (int)Math.Round(bodyMassIndex);
+    }
+
+    public static int CalculateCalorieNeeds(UserData userData)
+    {
+        if (userData.Weight <= 0 || userData.Height <= 0 || userData.Age <= 0)
+        {
+            return 0;
+        }
+
+        double basalMetabolicRate =
+            userData.Gender.Equals(GENDER_MALE, StringComparison.OrdinalIgnoreCase)
+                ? (BASAL_METABOLIC_RATE_WEIGHT_FACTOR * userData.Weight) +
+                  (BASAL_METABOLIC_RATE_HEIGHT_FACTOR * userData.Height) -
+                  (BASAL_METABOLIC_RATE_AGE_FACTOR * userData.Age) +
+                  BASAL_METABOLIC_RATE_MALE_OFFSET
+                : userData.Gender.Equals(GENDER_FEMALE, StringComparison.OrdinalIgnoreCase)
+                    ? (BASAL_METABOLIC_RATE_WEIGHT_FACTOR * userData.Weight) +
+                      (BASAL_METABOLIC_RATE_HEIGHT_FACTOR * userData.Height) -
+                      (BASAL_METABOLIC_RATE_AGE_FACTOR * userData.Age) -
+                      BASAL_METABOLIC_RATE_FEMALE_OFFSET
+                    : 0;
+
+        if (basalMetabolicRate <= 0)
+        {
+            return 0;
+        }
+
+        double totalDailyEnergyExpenditure = basalMetabolicRate * ACTIVITY_MULTIPLIER;
+
+        double adjustedCalories = userData.Goal.ToLower() switch
+        {
+            GOAL_BULK => totalDailyEnergyExpenditure + BULK_CALORIE_DELTA,
+            GOAL_CUT => totalDailyEnergyExpenditure + CUT_CALORIE_DELTA,
+            GOAL_MAINTENANCE => totalDailyEnergyExpenditure,
+            GOAL_WELL_BEING => totalDailyEnergyExpenditure,
+            _ => totalDailyEnergyExpenditure
+        };
+
+        return (int)Math.Round(adjustedCalories);
+    }
+
+    public static int CalculateProteinNeeds(UserData userData)
+    {
+        if (userData.Weight <= 0)
+        {
+            return 0;
+        }
+
+        double proteinPerKg = userData.Goal.ToLower() switch
+        {
+            GOAL_BULK => PROTEIN_BULK,
+            GOAL_CUT => PROTEIN_CUT,
+            GOAL_MAINTENANCE => PROTEIN_MAINTENANCE,
+            GOAL_WELL_BEING => PROTEIN_WELL_BEING,
+            _ => PROTEIN_MAINTENANCE
+        };
+
+        return (int)Math.Round(userData.Weight * proteinPerKg);
+    }
+
+    public static int CalculateFatNeeds(UserData userData)
+    {
+        int calories = CalculateCalorieNeeds(userData);
+        if (calories <= 0)
+        {
+            return 0;
+        }
+
+        double fatRatio = userData.Goal.ToLower() switch
+        {
+            GOAL_BULK or GOAL_CUT => FAT_BULK_CUT,
+            GOAL_MAINTENANCE => FAT_MAINTENANCE,
+            GOAL_WELL_BEING => FAT_WELL_BEING,
+            _ => FAT_BULK_CUT
+        };
+
+        double fatCalories = calories * fatRatio;
+        return (int)Math.Round(fatCalories / CALORIES_PER_GRAM_FAT);
+    }
+
+    public static int CalculateCarbohydrateNeeds(UserData userData)
+    {
+        int calories = CalculateCalorieNeeds(userData);
+        int proteinCalories = CalculateProteinNeeds(userData) * CALORIES_PER_GRAM_PROTEIN;
+        int fatCalories = CalculateFatNeeds(userData) * CALORIES_PER_GRAM_FAT;
+
+        if (calories <= 0)
+        {
+            return 0;
+        }
+
+        int carbohydrateCalories = Math.Max(0, calories - proteinCalories - fatCalories);
+        return (int)Math.Round(carbohydrateCalories / (double)CALORIES_PER_GRAM_CARBOHYDRATES);
+    }
+}

--- a/ClassLibrary/Services/NutritionCalculator.cs
+++ b/ClassLibrary/Services/NutritionCalculator.cs
@@ -69,13 +69,15 @@ public static class NutritionCalculator
             return 0;
         }
 
+        string gender = userData.Gender ?? string.Empty;
+
         double basalMetabolicRate =
-            userData.Gender.Equals(GENDER_MALE, StringComparison.OrdinalIgnoreCase)
+            gender.Equals(GENDER_MALE, StringComparison.OrdinalIgnoreCase)
                 ? (BASAL_METABOLIC_RATE_WEIGHT_FACTOR * userData.Weight) +
                   (BASAL_METABOLIC_RATE_HEIGHT_FACTOR * userData.Height) -
                   (BASAL_METABOLIC_RATE_AGE_FACTOR * userData.Age) +
                   BASAL_METABOLIC_RATE_MALE_OFFSET
-                : userData.Gender.Equals(GENDER_FEMALE, StringComparison.OrdinalIgnoreCase)
+                : gender.Equals(GENDER_FEMALE, StringComparison.OrdinalIgnoreCase)
                     ? (BASAL_METABOLIC_RATE_WEIGHT_FACTOR * userData.Weight) +
                       (BASAL_METABOLIC_RATE_HEIGHT_FACTOR * userData.Height) -
                       (BASAL_METABOLIC_RATE_AGE_FACTOR * userData.Age) -
@@ -89,7 +91,9 @@ public static class NutritionCalculator
 
         double totalDailyEnergyExpenditure = basalMetabolicRate * ACTIVITY_MULTIPLIER;
 
-        double adjustedCalories = userData.Goal.ToLower() switch
+        string goal = (userData.Goal ?? string.Empty).ToLowerInvariant();
+
+        double adjustedCalories = goal switch
         {
             GOAL_BULK => totalDailyEnergyExpenditure + BULK_CALORIE_DELTA,
             GOAL_CUT => totalDailyEnergyExpenditure + CUT_CALORIE_DELTA,
@@ -108,7 +112,9 @@ public static class NutritionCalculator
             return 0;
         }
 
-        double proteinPerKg = userData.Goal.ToLower() switch
+        string goal = (userData.Goal ?? string.Empty).ToLowerInvariant();
+
+        double proteinPerKg = goal switch
         {
             GOAL_BULK => PROTEIN_BULK,
             GOAL_CUT => PROTEIN_CUT,
@@ -128,7 +134,9 @@ public static class NutritionCalculator
             return 0;
         }
 
-        double fatRatio = userData.Goal.ToLower() switch
+        string goal = (userData.Goal ?? string.Empty).ToLowerInvariant();
+
+        double fatRatio = goal switch
         {
             GOAL_BULK or GOAL_CUT => FAT_BULK_CUT,
             GOAL_MAINTENANCE => FAT_MAINTENANCE,


### PR DESCRIPTION
Fixes for the model issues flagged in the group chat.

**UserData had business logic:** Extracted all calculation methods (BMI, calorie needs, protein, fat, carbohydrate needs) into a static `NutritionCalculator` class under `ClassLibrary/Services`. UserData is now a clean POCO with just properties and validation attributes.

**FoodItemFilter is not a DB entity:** Moved it from `ClassLibrary/Models` to `ClassLibrary/Filters` with its own namespace. It was never registered as a DbSet, it's just a query filter object.

**FK IDs on our models:** Favorite, FoodItemIngredient, MealPlanFoodItem, MealPlan, and Inventory already have both FK properties and navigation properties (e.g. `int UserId` + `User User`), which is the standard EF Core pattern. Removing the FK ints would break every repository query that filters by UserId, FoodItemId, etc. Nothing to fix here.

**Other models that actually need fixing:** Notification and WorkoutLog only have navigation properties with no FK ID (e.g. `Client Client` but no `int ClientId`). That's the opposite problem: EF Core falls back to shadow properties which makes querying less explicit. Those aren't from our integration though.