### PR TITLE
notification logic

### DIFF
--- a/ClassLibrary/IRepositories/INotificationRepository.cs
+++ b/ClassLibrary/IRepositories/INotificationRepository.cs
@@ -6,5 +6,5 @@ public interface INotificationRepository
 {
     Task<IReadOnlyList<Notification>> GetNotificationsAsync(int clientId, CancellationToken cancellationToken = default);
 
-    Task<bool> SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default);
+    Task SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default);
 }

--- a/ClassLibrary/Repositories/NotificationRepository.cs
+++ b/ClassLibrary/Repositories/NotificationRepository.cs
@@ -26,7 +26,7 @@ public sealed class NotificationRepository : INotificationRepository
 
     public async Task SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
     {
-        notification.DateCreated = DateTime.Now;
+        notification.DateCreated = DateTime.UtcNow;
         notification.IsRead = false;
         await this.databaseContext.Notifications.AddAsync(notification, cancellationToken);
         await this.databaseContext.SaveChangesAsync(cancellationToken);

--- a/ClassLibrary/Repositories/NotificationRepository.cs
+++ b/ClassLibrary/Repositories/NotificationRepository.cs
@@ -24,9 +24,15 @@ public sealed class NotificationRepository : INotificationRepository
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<bool> SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
+    public async Task SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
     {
+        notification.DateCreated = DateTime.Now;
+        notification.IsRead = false;
         await this.databaseContext.Notifications.AddAsync(notification, cancellationToken);
-        return await this.databaseContext.SaveChangesAsync(cancellationToken) > 0;
+        var rowsAffected = await this.databaseContext.SaveChangesAsync(cancellationToken);
+        if (rowsAffected == 0)
+        {
+            throw new Exception("Notification could not be saved.");
+        }
     }
 }

--- a/ClassLibrary/Repositories/NotificationRepository.cs
+++ b/ClassLibrary/Repositories/NotificationRepository.cs
@@ -26,8 +26,10 @@ public sealed class NotificationRepository : INotificationRepository
 
     public async Task SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
     {
-        notification.DateCreated = DateTime.Now;
-        notification.IsRead = false;
+        if (notification.DateCreated == default)
+        {
+            notification.DateCreated = DateTime.Now;
+        }
         await this.databaseContext.Notifications.AddAsync(notification, cancellationToken);
         var rowsAffected = await this.databaseContext.SaveChangesAsync(cancellationToken);
         if (rowsAffected == 0)

--- a/ClassLibrary/Repositories/NotificationRepository.cs
+++ b/ClassLibrary/Repositories/NotificationRepository.cs
@@ -26,7 +26,7 @@ public sealed class NotificationRepository : INotificationRepository
 
     public async Task SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
     {
-        notification.DateCreated = DateTime.UtcNow;
+        notification.DateCreated = DateTime.Now;
         notification.IsRead = false;
         await this.databaseContext.Notifications.AddAsync(notification, cancellationToken);
         await this.databaseContext.SaveChangesAsync(cancellationToken);

--- a/ClassLibrary/Repositories/NotificationRepository.cs
+++ b/ClassLibrary/Repositories/NotificationRepository.cs
@@ -26,10 +26,8 @@ public sealed class NotificationRepository : INotificationRepository
 
     public async Task SaveNotificationAsync(Notification notification, CancellationToken cancellationToken = default)
     {
-        if (notification.DateCreated == default)
-        {
-            notification.DateCreated = DateTime.Now;
-        }
+        notification.DateCreated = DateTime.Now;
+        notification.IsRead = false;
         await this.databaseContext.Notifications.AddAsync(notification, cancellationToken);
         await this.databaseContext.SaveChangesAsync(cancellationToken);
     }

--- a/ClassLibrary/Repositories/NotificationRepository.cs
+++ b/ClassLibrary/Repositories/NotificationRepository.cs
@@ -31,10 +31,6 @@ public sealed class NotificationRepository : INotificationRepository
             notification.DateCreated = DateTime.Now;
         }
         await this.databaseContext.Notifications.AddAsync(notification, cancellationToken);
-        var rowsAffected = await this.databaseContext.SaveChangesAsync(cancellationToken);
-        if (rowsAffected == 0)
-        {
-            throw new InvalidOperationException("Notification could not be saved.");
-        }
+        await this.databaseContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/ClassLibrary/Repositories/NotificationRepository.cs
+++ b/ClassLibrary/Repositories/NotificationRepository.cs
@@ -32,7 +32,7 @@ public sealed class NotificationRepository : INotificationRepository
         var rowsAffected = await this.databaseContext.SaveChangesAsync(cancellationToken);
         if (rowsAffected == 0)
         {
-            throw new Exception("Notification could not be saved.");
+            throw new InvalidOperationException("Notification could not be saved.");
         }
     }
 }


### PR DESCRIPTION
SaveNotificationAsync now explicitly sets DateCreated = DateTime.Now and IsRead = false before persisting. Removed bool return type in favor of exceptions (Task instead of Task<bool>). Updated INotificationRepository interface accordingly.

Issue #96 