### PR TITLE
Integrate InventoryService with controller, DTOs and repository

### DIFF
--- a/ClassLibrary/DTOs/AddIngredientByNameRequestDataTransferObject.cs
+++ b/ClassLibrary/DTOs/AddIngredientByNameRequestDataTransferObject.cs
@@ -1,0 +1,8 @@
+namespace ClassLibrary.DTOs;
+
+public sealed class AddIngredientByNameRequestDataTransferObject
+{
+    public int UserId { get; set; }
+
+    public string IngredientName { get; set; } = string.Empty;
+}

--- a/ClassLibrary/DTOs/AddToPantryRequestDataTransferObject.cs
+++ b/ClassLibrary/DTOs/AddToPantryRequestDataTransferObject.cs
@@ -1,0 +1,10 @@
+namespace ClassLibrary.DTOs;
+
+public sealed class AddToPantryRequestDataTransferObject
+{
+    public int UserId { get; set; }
+
+    public int IngredientId { get; set; }
+
+    public int QuantityGrams { get; set; }
+}

--- a/ClassLibrary/DTOs/ConsumeMealRequestDataTransferObject.cs
+++ b/ClassLibrary/DTOs/ConsumeMealRequestDataTransferObject.cs
@@ -1,0 +1,8 @@
+namespace ClassLibrary.DTOs;
+
+public sealed class ConsumeMealRequestDataTransferObject
+{
+    public int UserId { get; set; }
+
+    public int MealPlanId { get; set; }
+}

--- a/ClassLibrary/DTOs/IngredientDataTransferObject.cs
+++ b/ClassLibrary/DTOs/IngredientDataTransferObject.cs
@@ -1,0 +1,16 @@
+namespace ClassLibrary.DTOs;
+
+public sealed class IngredientDataTransferObject
+{
+    public int IngredientId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public double CaloriesPer100g { get; set; }
+
+    public double ProteinPer100g { get; set; }
+
+    public double CarbohydratesPer100g { get; set; }
+
+    public double FatPer100g { get; set; }
+}

--- a/ClassLibrary/DTOs/InventoryDataTransferObject.cs
+++ b/ClassLibrary/DTOs/InventoryDataTransferObject.cs
@@ -1,0 +1,12 @@
+namespace ClassLibrary.DTOs;
+
+public sealed class InventoryDataTransferObject
+{
+    public int InventoryId { get; set; }
+
+    public int IngredientId { get; set; }
+
+    public string IngredientName { get; set; } = string.Empty;
+
+    public int QuantityGrams { get; set; }
+}

--- a/ClassLibrary/Extensions/DataAccessServiceCollectionExtensions.cs
+++ b/ClassLibrary/Extensions/DataAccessServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class DataAccessServiceCollectionExtensions
         services.AddScoped<IWorkoutTemplateRepository, WorkoutTemplateRepository>();
         services.AddScoped<IClientRepository, ClientRepository>();
         services.AddScoped<IIngredientRepository, IngredientRepository>();
+        services.AddScoped<IInventoryRepository, InventoryRepository>();
         services.AddScoped<IReminderRepository, ReminderRepository>();
         services.AddScoped<IShoppingListRepository, ShoppingListRepository>();
         services.AddScoped<IWorkoutAnalyticsRepository, WorkoutAnalyticsRepository>();

--- a/ClassLibrary/IRepositories/IInventoryRepository.cs
+++ b/ClassLibrary/IRepositories/IInventoryRepository.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Models;
+
+namespace ClassLibrary.IRepositories;
+
+public interface IInventoryRepository
+{
+    Task<IReadOnlyList<Inventory>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task AddAsync(Inventory inventory, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(Inventory inventory, CancellationToken cancellationToken = default);
+
+    Task DeleteAsync(int inventoryId, CancellationToken cancellationToken = default);
+}

--- a/ClassLibrary/IRepositories/IMealPlanRepository.cs
+++ b/ClassLibrary/IRepositories/IMealPlanRepository.cs
@@ -26,4 +26,6 @@ public interface IMealPlanRepository
     Task AddIngredientToFoodItemAsync(int foodItemId, int ingredientId, CancellationToken cancellationToken = default);
 
     Task RemoveIngredientFromFoodItemAsync(int foodItemId, int ingredientId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<int>> GetIngredientIdsForMealPlanAsync(int mealPlanId, CancellationToken cancellationToken = default);
 }

--- a/ClassLibrary/Repositories/InventoryRepository.cs
+++ b/ClassLibrary/Repositories/InventoryRepository.cs
@@ -38,9 +38,13 @@ public sealed class InventoryRepository : IInventoryRepository
 
     public async Task AddAsync(Inventory inventory, CancellationToken cancellationToken = default)
     {
-        var entry = this.databaseContext.Entry(inventory);
-        var userId = entry.Property<int>("UserId").CurrentValue;
-        var ingredientId = entry.Property<int>("IngredientId").CurrentValue;
+        var userId = inventory.User?.UserId ?? 0;
+        var ingredientId = inventory.Ingredient?.IngredientId ?? 0;
+
+        if (userId <= 0 || ingredientId <= 0)
+        {
+            throw new ArgumentException("Inventory must include User and Ingredient navigation stubs with valid key values.");
+        }
 
         var existing = await this.GetByUserIdAndIngredientIdAsync(userId, ingredientId, cancellationToken);
         if (existing is not null)

--- a/ClassLibrary/Repositories/InventoryRepository.cs
+++ b/ClassLibrary/Repositories/InventoryRepository.cs
@@ -26,9 +26,32 @@ public sealed class InventoryRepository : IInventoryRepository
             .ToListAsync(cancellationToken);
     }
 
+    private async Task<Inventory?> GetByUserIdAndIngredientIdAsync(int userId, int ingredientId, CancellationToken cancellationToken)
+    {
+        return await this.databaseContext.Inventories
+            .FirstOrDefaultAsync(
+                existingInventory =>
+                    EF.Property<int>(existingInventory, "UserId") == userId &&
+                    EF.Property<int>(existingInventory, "IngredientId") == ingredientId,
+                cancellationToken);
+    }
+
     public async Task AddAsync(Inventory inventory, CancellationToken cancellationToken = default)
     {
-        this.databaseContext.Inventories.Add(inventory);
+        var entry = this.databaseContext.Entry(inventory);
+        var userId = entry.Property<int>("UserId").CurrentValue;
+        var ingredientId = entry.Property<int>("IngredientId").CurrentValue;
+
+        var existing = await this.GetByUserIdAndIngredientIdAsync(userId, ingredientId, cancellationToken);
+        if (existing is not null)
+        {
+            existing.QuantityGrams += inventory.QuantityGrams;
+        }
+        else
+        {
+            this.databaseContext.Inventories.Add(inventory);
+        }
+
         await this.databaseContext.SaveChangesAsync(cancellationToken);
     }
 

--- a/ClassLibrary/Repositories/InventoryRepository.cs
+++ b/ClassLibrary/Repositories/InventoryRepository.cs
@@ -22,7 +22,6 @@ public sealed class InventoryRepository : IInventoryRepository
         return await this.databaseContext.Inventories
             .AsNoTracking()
             .Include(inventory => inventory.Ingredient)
-            .Include(inventory => inventory.User)
             .Where(inventory => EF.Property<int>(inventory, "UserId") == userId)
             .ToListAsync(cancellationToken);
     }

--- a/ClassLibrary/Repositories/InventoryRepository.cs
+++ b/ClassLibrary/Repositories/InventoryRepository.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.Data;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClassLibrary.Repositories;
+
+public sealed class InventoryRepository : IInventoryRepository
+{
+    private readonly AppDbContext databaseContext;
+
+    public InventoryRepository(AppDbContext databaseContext)
+    {
+        this.databaseContext = databaseContext;
+    }
+
+    public async Task<IReadOnlyList<Inventory>> GetAllByUserIdAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        return await this.databaseContext.Inventories
+            .AsNoTracking()
+            .Include(inventory => inventory.Ingredient)
+            .Include(inventory => inventory.User)
+            .Where(inventory => EF.Property<int>(inventory, "UserId") == userId)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Inventory inventory, CancellationToken cancellationToken = default)
+    {
+        this.databaseContext.Inventories.Add(inventory);
+        await this.databaseContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(Inventory inventory, CancellationToken cancellationToken = default)
+    {
+        var existing = await this.databaseContext.Inventories.FindAsync([inventory.InventoryId], cancellationToken);
+        if (existing is not null)
+        {
+            existing.QuantityGrams = inventory.QuantityGrams;
+            await this.databaseContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task DeleteAsync(int inventoryId, CancellationToken cancellationToken = default)
+    {
+        var entity = await this.databaseContext.Inventories.FindAsync([inventoryId], cancellationToken);
+        if (entity is not null)
+        {
+            this.databaseContext.Inventories.Remove(entity);
+            await this.databaseContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/ClassLibrary/Repositories/MealPlanRepository.cs
+++ b/ClassLibrary/Repositories/MealPlanRepository.cs
@@ -129,4 +129,20 @@ public sealed class MealPlanRepository(AppDbContext dbContext) : IMealPlanReposi
         }
     }
 
+    public async Task<IReadOnlyList<int>> GetIngredientIdsForMealPlanAsync(int mealPlanId, CancellationToken cancellationToken = default)
+    {
+        var foodItemIds = await dbContext.MealPlanFoodItems
+            .AsNoTracking()
+            .Where(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "MealPlanId") == mealPlanId)
+            .Select(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "FoodItemId"))
+            .ToListAsync(cancellationToken);
+
+        return await dbContext.FoodItemIngredients
+            .AsNoTracking()
+            .Where(foodItemIngredient => foodItemIds.Contains(EF.Property<int>(foodItemIngredient, "FoodItemId")))
+            .Select(foodItemIngredient => EF.Property<int>(foodItemIngredient, "IngredientId"))
+            .Distinct()
+            .ToListAsync(cancellationToken);
+    }
+
 }

--- a/ClassLibrary/Repositories/MealPlanRepository.cs
+++ b/ClassLibrary/Repositories/MealPlanRepository.cs
@@ -131,15 +131,14 @@ public sealed class MealPlanRepository(AppDbContext dbContext) : IMealPlanReposi
 
     public async Task<IReadOnlyList<int>> GetIngredientIdsForMealPlanAsync(int mealPlanId, CancellationToken cancellationToken = default)
     {
-        return await dbContext.FoodItemIngredients
+        return await dbContext.MealPlanFoodItems
             .AsNoTracking()
-            .Where(
-                foodItemIngredient => dbContext.MealPlanFoodItems
-                    .AsNoTracking()
-                    .Where(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "MealPlanId") == mealPlanId)
-                    .Select(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "FoodItemId"))
-                    .Contains(EF.Property<int>(foodItemIngredient, "FoodItemId")))
-            .Select(foodItemIngredient => EF.Property<int>(foodItemIngredient, "IngredientId"))
+            .Where(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "MealPlanId") == mealPlanId)
+            .Join(
+                dbContext.FoodItemIngredients.AsNoTracking(),
+                mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "FoodItemId"),
+                foodItemIngredient => EF.Property<int>(foodItemIngredient, "FoodItemId"),
+                (_, foodItemIngredient) => EF.Property<int>(foodItemIngredient, "IngredientId"))
             .ToListAsync(cancellationToken);
     }
 

--- a/ClassLibrary/Repositories/MealPlanRepository.cs
+++ b/ClassLibrary/Repositories/MealPlanRepository.cs
@@ -140,7 +140,6 @@ public sealed class MealPlanRepository(AppDbContext dbContext) : IMealPlanReposi
                     .Select(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "FoodItemId"))
                     .Contains(EF.Property<int>(foodItemIngredient, "FoodItemId")))
             .Select(foodItemIngredient => EF.Property<int>(foodItemIngredient, "IngredientId"))
-            .Distinct()
             .ToListAsync(cancellationToken);
     }
 

--- a/ClassLibrary/Repositories/MealPlanRepository.cs
+++ b/ClassLibrary/Repositories/MealPlanRepository.cs
@@ -131,15 +131,14 @@ public sealed class MealPlanRepository(AppDbContext dbContext) : IMealPlanReposi
 
     public async Task<IReadOnlyList<int>> GetIngredientIdsForMealPlanAsync(int mealPlanId, CancellationToken cancellationToken = default)
     {
-        var foodItemIds = await dbContext.MealPlanFoodItems
-            .AsNoTracking()
-            .Where(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "MealPlanId") == mealPlanId)
-            .Select(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "FoodItemId"))
-            .ToListAsync(cancellationToken);
-
         return await dbContext.FoodItemIngredients
             .AsNoTracking()
-            .Where(foodItemIngredient => foodItemIds.Contains(EF.Property<int>(foodItemIngredient, "FoodItemId")))
+            .Where(
+                foodItemIngredient => dbContext.MealPlanFoodItems
+                    .AsNoTracking()
+                    .Where(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "MealPlanId") == mealPlanId)
+                    .Select(mealPlanFoodItem => EF.Property<int>(mealPlanFoodItem, "FoodItemId"))
+                    .Contains(EF.Property<int>(foodItemIngredient, "FoodItemId")))
             .Select(foodItemIngredient => EF.Property<int>(foodItemIngredient, "IngredientId"))
             .Distinct()
             .ToListAsync(cancellationToken);

--- a/WebAPI/Controllers/InventoryController.cs
+++ b/WebAPI/Controllers/InventoryController.cs
@@ -55,7 +55,7 @@ public sealed class InventoryController : ControllerBase
         return this.Ok();
     }
 
-    [HttpDelete("{inventoryId}")]
+    [HttpDelete("{inventoryId:int}")]
     public async Task<IActionResult> RemoveItem(int inventoryId, CancellationToken cancellationToken)
     {
         await this.inventoryService.RemoveItemAsync(inventoryId, cancellationToken);

--- a/WebAPI/Controllers/InventoryController.cs
+++ b/WebAPI/Controllers/InventoryController.cs
@@ -1,0 +1,64 @@
+using ClassLibrary.DTOs;
+using Microsoft.AspNetCore.Mvc;
+using WebAPI.Services.Interfaces;
+
+namespace WebAPI.Controllers;
+
+[ApiController]
+[Route("api/inventory")]
+public sealed class InventoryController : ControllerBase
+{
+    private readonly IInventoryService inventoryService;
+
+    public InventoryController(IInventoryService inventoryService)
+    {
+        this.inventoryService = inventoryService;
+    }
+
+    [HttpGet("{userId}")]
+    public async Task<IActionResult> GetUserInventory(int userId, CancellationToken cancellationToken)
+    {
+        var inventory = await this.inventoryService.GetUserInventoryAsync(userId, cancellationToken);
+        return this.Ok(inventory);
+    }
+
+    [HttpGet("ingredients")]
+    public async Task<IActionResult> GetAllIngredients(CancellationToken cancellationToken)
+    {
+        var ingredients = await this.inventoryService.GetAllIngredientsAsync(cancellationToken);
+        return this.Ok(ingredients);
+    }
+
+    [HttpPost("add-to-pantry")]
+    public async Task<IActionResult> AddToPantry([FromBody] AddToPantryRequestDataTransferObject request, CancellationToken cancellationToken)
+    {
+        await this.inventoryService.AddToPantryAsync(request, cancellationToken);
+        return this.Ok();
+    }
+
+    [HttpPost("add-ingredient-by-name")]
+    public async Task<IActionResult> AddIngredientByName([FromBody] AddIngredientByNameRequestDataTransferObject request, CancellationToken cancellationToken)
+    {
+        await this.inventoryService.AddIngredientByNameToPantryAsync(request, cancellationToken);
+        return this.Ok();
+    }
+
+    [HttpPost("consume-meal")]
+    public async Task<IActionResult> ConsumeMeal([FromBody] ConsumeMealRequestDataTransferObject request, CancellationToken cancellationToken)
+    {
+        var success = await this.inventoryService.ConsumeMealAsync(request, cancellationToken);
+        if (!success)
+        {
+            return this.BadRequest("Insufficient ingredients in inventory to consume meal.");
+        }
+
+        return this.Ok();
+    }
+
+    [HttpDelete("{inventoryId}")]
+    public async Task<IActionResult> RemoveItem(int inventoryId, CancellationToken cancellationToken)
+    {
+        await this.inventoryService.RemoveItemAsync(inventoryId, cancellationToken);
+        return this.Ok();
+    }
+}

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IClientService, ClientService>();
         services.AddScoped<IFoodItemService, FoodItemService>();
         services.AddScoped<IMealPlanService, MealPlanService>();
+        services.AddScoped<IInventoryService, InventoryService>();
         return services;
     }
 }

--- a/WebAPI/Services/Interfaces/IInventoryService.cs
+++ b/WebAPI/Services/Interfaces/IInventoryService.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.DTOs;
+
+namespace WebAPI.Services.Interfaces;
+
+public interface IInventoryService
+{
+    Task<bool> ConsumeMealAsync(ConsumeMealRequestDataTransferObject request, CancellationToken cancellationToken = default);
+
+    Task AddToPantryAsync(AddToPantryRequestDataTransferObject request, CancellationToken cancellationToken = default);
+
+    Task AddIngredientByNameToPantryAsync(AddIngredientByNameRequestDataTransferObject request, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InventoryDataTransferObject>> GetUserInventoryAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task RemoveItemAsync(int inventoryId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<IngredientDataTransferObject>> GetAllIngredientsAsync(CancellationToken cancellationToken = default);
+}

--- a/WebAPI/Services/InventoryService.cs
+++ b/WebAPI/Services/InventoryService.cs
@@ -119,7 +119,7 @@ public sealed class InventoryService : IInventoryService
 
     public async Task<IReadOnlyList<IngredientDataTransferObject>> GetAllIngredientsAsync(CancellationToken cancellationToken = default)
     {
-        var ingredients = await this.ingredientRepository.GetAllAsync().WaitAsync(cancellationToken);
+        var ingredients = await this.ingredientRepository.GetAllAsync();
         return ingredients.Select(MapToIngredientDto).ToList();
     }
 

--- a/WebAPI/Services/InventoryService.cs
+++ b/WebAPI/Services/InventoryService.cs
@@ -30,17 +30,21 @@ public sealed class InventoryService : IInventoryService
     public async Task<bool> ConsumeMealAsync(ConsumeMealRequestDataTransferObject request, CancellationToken cancellationToken = default)
     {
         var requiredIngredientIds = await this.mealPlanRepository.GetIngredientIdsForMealPlanAsync(request.MealPlanId, cancellationToken);
-        var inventoryItems = (await this.inventoryRepository.GetAllByUserIdAsync(request.UserId, cancellationToken)).ToList();
+        var inventoryByIngredientId = (await this.inventoryRepository.GetAllByUserIdAsync(request.UserId, cancellationToken))
+            .GroupBy(inventoryItem => inventoryItem.Ingredient.IngredientId)
+            .ToDictionary(group => group.Key, group => group.First());
 
         foreach (int ingredientId in requiredIngredientIds)
         {
-            var stock = inventoryItems.FirstOrDefault(item => item.Ingredient.IngredientId == ingredientId);
-
-            if (stock == null || stock.QuantityGrams < DefaultIngredientsQuantity)
+            if (!inventoryByIngredientId.TryGetValue(ingredientId, out var stock) || stock.QuantityGrams < DefaultIngredientsQuantity)
             {
                 return false;
             }
+        }
 
+        foreach (int ingredientId in requiredIngredientIds)
+        {
+            var stock = inventoryByIngredientId[ingredientId];
             stock.QuantityGrams -= DefaultIngredientsQuantity;
 
             if (stock.QuantityGrams <= 0)

--- a/WebAPI/Services/InventoryService.cs
+++ b/WebAPI/Services/InventoryService.cs
@@ -15,7 +15,7 @@ public sealed class InventoryService : IInventoryService
     private readonly IMealPlanRepository mealPlanRepository;
     private readonly IIngredientRepository ingredientRepository;
 
-    private const int DefaultIngredientsQuantity = 100;
+    private const int DEFAULT_INGREDIENTS_QUANTITY = 100;
 
     public InventoryService(
         IIngredientRepository ingredientRepository,
@@ -36,7 +36,7 @@ public sealed class InventoryService : IInventoryService
 
         foreach (int ingredientId in requiredIngredientIds)
         {
-            if (!inventoryByIngredientId.TryGetValue(ingredientId, out var stock) || stock.QuantityGrams < DefaultIngredientsQuantity)
+            if (!inventoryByIngredientId.TryGetValue(ingredientId, out var stock) || stock.QuantityGrams < DEFAULT_INGREDIENTS_QUANTITY)
             {
                 return false;
             }
@@ -45,7 +45,7 @@ public sealed class InventoryService : IInventoryService
         foreach (int ingredientId in requiredIngredientIds)
         {
             var stock = inventoryByIngredientId[ingredientId];
-            stock.QuantityGrams -= DefaultIngredientsQuantity;
+            stock.QuantityGrams -= DEFAULT_INGREDIENTS_QUANTITY;
 
             if (stock.QuantityGrams <= 0)
             {
@@ -79,7 +79,7 @@ public sealed class InventoryService : IInventoryService
         {
             UserId = request.UserId,
             IngredientId = ingredientId,
-            QuantityGrams = DefaultIngredientsQuantity,
+            QuantityGrams = DEFAULT_INGREDIENTS_QUANTITY,
         }, cancellationToken);
     }
 

--- a/WebAPI/Services/InventoryService.cs
+++ b/WebAPI/Services/InventoryService.cs
@@ -119,7 +119,11 @@ public sealed class InventoryService : IInventoryService
 
     public async Task<IReadOnlyList<IngredientDataTransferObject>> GetAllIngredientsAsync(CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var ingredients = await this.ingredientRepository.GetAllAsync();
+
+        cancellationToken.ThrowIfCancellationRequested();
         return ingredients.Select(MapToIngredientDto).ToList();
     }
 

--- a/WebAPI/Services/InventoryService.cs
+++ b/WebAPI/Services/InventoryService.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using WebAPI.Services.Interfaces;
+
+namespace WebAPI.Services;
+
+public sealed class InventoryService : IInventoryService
+{
+    private readonly IInventoryRepository inventoryRepository;
+    private readonly IMealPlanRepository mealPlanRepository;
+    private readonly IIngredientRepository ingredientRepository;
+
+    private const int DefaultIngredientsQuantity = 100;
+
+    public InventoryService(
+        IIngredientRepository ingredientRepository,
+        IInventoryRepository inventoryRepository,
+        IMealPlanRepository mealPlanRepository)
+    {
+        this.inventoryRepository = inventoryRepository;
+        this.mealPlanRepository = mealPlanRepository;
+        this.ingredientRepository = ingredientRepository;
+    }
+
+    public async Task<bool> ConsumeMealAsync(ConsumeMealRequestDataTransferObject request, CancellationToken cancellationToken = default)
+    {
+        var requiredIngredientIds = await this.mealPlanRepository.GetIngredientIdsForMealPlanAsync(request.MealPlanId, cancellationToken);
+        var inventoryItems = (await this.inventoryRepository.GetAllByUserIdAsync(request.UserId, cancellationToken)).ToList();
+
+        foreach (int ingredientId in requiredIngredientIds)
+        {
+            var stock = inventoryItems.FirstOrDefault(item => item.Ingredient.IngredientId == ingredientId);
+
+            if (stock == null || stock.QuantityGrams < DefaultIngredientsQuantity)
+            {
+                return false;
+            }
+
+            stock.QuantityGrams -= DefaultIngredientsQuantity;
+
+            if (stock.QuantityGrams <= 0)
+            {
+                await this.inventoryRepository.DeleteAsync(stock.InventoryId, cancellationToken);
+            }
+            else
+            {
+                await this.inventoryRepository.UpdateAsync(stock, cancellationToken);
+            }
+        }
+
+        return true;
+    }
+
+    public async Task AddToPantryAsync(AddToPantryRequestDataTransferObject request, CancellationToken cancellationToken = default)
+    {
+        var newItem = new Inventory
+        {
+            User = new User { UserId = request.UserId },
+            Ingredient = new Ingredient { IngredientId = request.IngredientId },
+            QuantityGrams = request.QuantityGrams,
+        };
+
+        await this.inventoryRepository.AddAsync(newItem, cancellationToken);
+    }
+
+    public async Task AddIngredientByNameToPantryAsync(AddIngredientByNameRequestDataTransferObject request, CancellationToken cancellationToken = default)
+    {
+        int ingredientId = await this.ingredientRepository.GetOrCreateIngredientIdByNameAsync(request.IngredientName);
+        await this.AddToPantryAsync(new AddToPantryRequestDataTransferObject
+        {
+            UserId = request.UserId,
+            IngredientId = ingredientId,
+            QuantityGrams = DefaultIngredientsQuantity,
+        }, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<InventoryDataTransferObject>> GetUserInventoryAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        var inventoryItems = await this.inventoryRepository.GetAllByUserIdAsync(userId, cancellationToken);
+        return inventoryItems.Select(MapToInventoryDto).ToList();
+    }
+
+    public async Task RemoveItemAsync(int inventoryId, CancellationToken cancellationToken = default)
+    {
+        await this.inventoryRepository.DeleteAsync(inventoryId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<IngredientDataTransferObject>> GetAllIngredientsAsync(CancellationToken cancellationToken = default)
+    {
+        var ingredients = await this.ingredientRepository.GetAllAsync();
+        return ingredients.Select(MapToIngredientDto).ToList();
+    }
+
+    private static InventoryDataTransferObject MapToInventoryDto(Inventory inventory)
+    {
+        return new InventoryDataTransferObject
+        {
+            InventoryId = inventory.InventoryId,
+            IngredientId = inventory.Ingredient.IngredientId,
+            IngredientName = inventory.Ingredient.Name,
+            QuantityGrams = inventory.QuantityGrams,
+        };
+    }
+
+    private static IngredientDataTransferObject MapToIngredientDto(Ingredient ingredient)
+    {
+        return new IngredientDataTransferObject
+        {
+            IngredientId = ingredient.IngredientId,
+            Name = ingredient.Name,
+            CaloriesPer100g = ingredient.CaloriesPer100g,
+            ProteinPer100g = ingredient.ProteinPer100g,
+            CarbohydratesPer100g = ingredient.CarbohydratesPer100g,
+            FatPer100g = ingredient.FatPer100g,
+        };
+    }
+}

--- a/WebAPI/Services/InventoryService.cs
+++ b/WebAPI/Services/InventoryService.cs
@@ -30,30 +30,53 @@ public sealed class InventoryService : IInventoryService
     public async Task<bool> ConsumeMealAsync(ConsumeMealRequestDataTransferObject request, CancellationToken cancellationToken = default)
     {
         var requiredIngredientIds = await this.mealPlanRepository.GetIngredientIdsForMealPlanAsync(request.MealPlanId, cancellationToken);
+        var requiredQuantityByIngredientId = requiredIngredientIds
+            .GroupBy(ingredientId => ingredientId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Count() * DEFAULT_INGREDIENTS_QUANTITY);
+
         var inventoryByIngredientId = (await this.inventoryRepository.GetAllByUserIdAsync(request.UserId, cancellationToken))
             .GroupBy(inventoryItem => inventoryItem.Ingredient.IngredientId)
-            .ToDictionary(group => group.Key, group => group.First());
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(inventoryItem => inventoryItem.InventoryId).ToList());
 
-        foreach (int ingredientId in requiredIngredientIds)
+        foreach (var requiredIngredient in requiredQuantityByIngredientId)
         {
-            if (!inventoryByIngredientId.TryGetValue(ingredientId, out var stock) || stock.QuantityGrams < DEFAULT_INGREDIENTS_QUANTITY)
+            if (!inventoryByIngredientId.TryGetValue(requiredIngredient.Key, out var stocks) ||
+                stocks.Sum(stock => stock.QuantityGrams) < requiredIngredient.Value)
             {
                 return false;
             }
         }
 
-        foreach (int ingredientId in requiredIngredientIds)
+        foreach (var requiredIngredient in requiredQuantityByIngredientId)
         {
-            var stock = inventoryByIngredientId[ingredientId];
-            stock.QuantityGrams -= DEFAULT_INGREDIENTS_QUANTITY;
+            int remainingQuantityToConsume = requiredIngredient.Value;
 
-            if (stock.QuantityGrams <= 0)
+            foreach (var stock in inventoryByIngredientId[requiredIngredient.Key])
             {
-                await this.inventoryRepository.DeleteAsync(stock.InventoryId, cancellationToken);
-            }
-            else
-            {
-                await this.inventoryRepository.UpdateAsync(stock, cancellationToken);
+                if (remainingQuantityToConsume <= 0)
+                {
+                    break;
+                }
+
+                int quantityToConsume = stock.QuantityGrams >= remainingQuantityToConsume
+                    ? remainingQuantityToConsume
+                    : stock.QuantityGrams;
+
+                stock.QuantityGrams -= quantityToConsume;
+                remainingQuantityToConsume -= quantityToConsume;
+
+                if (stock.QuantityGrams <= 0)
+                {
+                    await this.inventoryRepository.DeleteAsync(stock.InventoryId, cancellationToken);
+                }
+                else
+                {
+                    await this.inventoryRepository.UpdateAsync(stock, cancellationToken);
+                }
             }
         }
 
@@ -96,7 +119,7 @@ public sealed class InventoryService : IInventoryService
 
     public async Task<IReadOnlyList<IngredientDataTransferObject>> GetAllIngredientsAsync(CancellationToken cancellationToken = default)
     {
-        var ingredients = await this.ingredientRepository.GetAllAsync();
+        var ingredients = await this.ingredientRepository.GetAllAsync().WaitAsync(cancellationToken);
         return ingredients.Select(MapToIngredientDto).ToList();
     }
 


### PR DESCRIPTION
Summary

Integrated NUTProject's InventoryService into WebAPI following the project's service/controller/DTO pattern
Created IInventoryRepository + InventoryRepository in ClassLibrary for inventory persistence
Added 5 DTOs (Inventory, Ingredient, ConsumeMealRequest, AddToPantryRequest, AddIngredientByNameRequest) so no domain models are exposed through endpoints
Added GetIngredientIdsForMealPlanAsync to IMealPlanRepository to support the ConsumeMeal flow (joins MealPlanFoodItems → FoodItemIngredients)
Registered IInventoryService in WebAPI extensions and IInventoryRepository in ClassLibrary extensions
Endpoints (api/inventory)

GET    /{userId}                 — get user's pantry
GET    /ingredients              — list all ingredients
POST   /add-to-pantry            — add ingredient by id + quantity
POST   /add-ingredient-by-name   — add ingredient by name (default 100g)
POST   /consume-meal             — deduct meal plan ingredients from pantry
DELETE /{inventoryId}            — remove pantry item

Notes

ConsumeMeal deducts a default 100g per ingredient because FoodItemIngredient does not store per-ingredient quantities in the current schema (the original NUTProject relied on a quantity field that doesn't exist here).

Test plan

Build passes (verified locally, 0 warnings / 0 errors)
GET /api/inventory/{userId} returns the user's pantry items
POST /api/inventory/add-to-pantry adds an item correctly
POST /api/inventory/add-ingredient-by-name creates the ingredient if missing and adds 100g
POST /api/inventory/consume-meal succeeds when stock is sufficient and returns 400 otherwise
DELETE /api/inventory/{inventoryId} removes the item