### PR TITLE
Logic Integration: NutritionPlanService and WorkoutLogService

### DIFF
--- a/ClassLibrary/DTOs/WorkoutLogDataTransferObject.cs
+++ b/ClassLibrary/DTOs/WorkoutLogDataTransferObject.cs
@@ -24,7 +24,7 @@ public sealed class WorkoutLogDataTransferObject
 
     public string IntensityTag { get; set; } = string.Empty;
 
-    public double Rating { get; set; }
+    public double? Rating { get; set; }
 
     public string TrainerNotes { get; set; } = string.Empty;
 }

--- a/Tests/NutritionPlanServiceTests.cs
+++ b/Tests/NutritionPlanServiceTests.cs
@@ -15,7 +15,7 @@ public sealed class NutritionPlanServiceTests
     public async Task CreatePlan_SetsStartDateToToday()
     {
         this.nutritionRepository
-            .Setup(r => r.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
+            .Setup(repository => repository.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
             .ReturnsAsync(1);
 
         var service = this.CreateService();
@@ -28,7 +28,7 @@ public sealed class NutritionPlanServiceTests
     public async Task CreatePlan_SetsEndDateToThirtyDaysFromToday()
     {
         this.nutritionRepository
-            .Setup(r => r.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
+            .Setup(repository => repository.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
             .ReturnsAsync(1);
 
         var service = this.CreateService();
@@ -42,7 +42,7 @@ public sealed class NutritionPlanServiceTests
     {
         NutritionPlan? capturedPlan = null;
         this.nutritionRepository
-            .Setup(r => r.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
+            .Setup(repository => repository.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
             .Callback<NutritionPlan>(plan => capturedPlan = plan)
             .ReturnsAsync(7);
 
@@ -52,7 +52,7 @@ public sealed class NutritionPlanServiceTests
         Assert.NotNull(capturedPlan);
         Assert.Equal(DateTime.Today, capturedPlan.StartDate);
         Assert.Equal(DateTime.Today.AddDays(30), capturedPlan.EndDate);
-        this.nutritionRepository.Verify(r => r.AssignNutritionPlanToClientAsync(42, 7), Times.Once);
+        this.nutritionRepository.Verify(repository => repository.AssignNutritionPlanToClientAsync(42, 7), Times.Once);
     }
 
     [Fact]
@@ -73,7 +73,7 @@ public sealed class NutritionPlanServiceTests
         };
 
         this.nutritionRepository
-            .Setup(r => r.GetNutritionPlansForClientAsync(5))
+            .Setup(repository => repository.GetNutritionPlansForClientAsync(5))
             .ReturnsAsync(plans);
 
         var service = this.CreateService();
@@ -90,7 +90,7 @@ public sealed class NutritionPlanServiceTests
     public async Task GetPlansForClient_WithNoPlans_ReturnsEmptyList()
     {
         this.nutritionRepository
-            .Setup(r => r.GetNutritionPlansForClientAsync(99))
+            .Setup(repository => repository.GetNutritionPlansForClientAsync(99))
             .ReturnsAsync(new List<NutritionPlan>());
 
         var service = this.CreateService();

--- a/Tests/NutritionPlanServiceTests.cs
+++ b/Tests/NutritionPlanServiceTests.cs
@@ -1,0 +1,101 @@
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class NutritionPlanServiceTests
+{
+    private readonly Mock<INutritionRepository> nutritionRepository = new();
+
+    private NutritionPlanService CreateService() => new(this.nutritionRepository.Object);
+
+    [Fact]
+    public async Task CreatePlan_SetsStartDateToToday()
+    {
+        this.nutritionRepository
+            .Setup(r => r.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
+            .ReturnsAsync(1);
+
+        var service = this.CreateService();
+        var result = await service.CreatePlanAsync(clientId: 42);
+
+        Assert.Equal(DateTime.Today, result.StartDate);
+    }
+
+    [Fact]
+    public async Task CreatePlan_SetsEndDateToThirtyDaysFromToday()
+    {
+        this.nutritionRepository
+            .Setup(r => r.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
+            .ReturnsAsync(1);
+
+        var service = this.CreateService();
+        var result = await service.CreatePlanAsync(clientId: 42);
+
+        Assert.Equal(DateTime.Today.AddDays(30), result.EndDate);
+    }
+
+    [Fact]
+    public async Task CreatePlan_PersistsThroughRepository()
+    {
+        NutritionPlan? capturedPlan = null;
+        this.nutritionRepository
+            .Setup(r => r.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
+            .Callback<NutritionPlan>(plan => capturedPlan = plan)
+            .ReturnsAsync(7);
+
+        var service = this.CreateService();
+        await service.CreatePlanAsync(clientId: 42);
+
+        Assert.NotNull(capturedPlan);
+        Assert.Equal(DateTime.Today, capturedPlan.StartDate);
+        Assert.Equal(DateTime.Today.AddDays(30), capturedPlan.EndDate);
+        this.nutritionRepository.Verify(r => r.AssignNutritionPlanToClientAsync(42, 7), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetPlansForClient_ReturnsMappedDtos()
+    {
+        var plans = new List<NutritionPlan>
+        {
+            new()
+            {
+                NutritionPlanId = 1,
+                StartDate = new DateTime(2026, 1, 1),
+                EndDate = new DateTime(2026, 1, 31),
+                Meals = new List<Meal>
+                {
+                    new() { MealId = 10, Name = "Breakfast", Ingredients = new List<string> { "Eggs" }, Instructions = "Scramble" },
+                },
+            },
+        };
+
+        this.nutritionRepository
+            .Setup(r => r.GetNutritionPlansForClientAsync(5))
+            .ReturnsAsync(plans);
+
+        var service = this.CreateService();
+        var result = await service.GetPlansForClientAsync(5);
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].NutritionPlanId);
+        Assert.Equal(new DateTime(2026, 1, 1), result[0].StartDate);
+        Assert.Single(result[0].Meals);
+        Assert.Equal("Breakfast", result[0].Meals[0].Name);
+    }
+
+    [Fact]
+    public async Task GetPlansForClient_WithNoPlans_ReturnsEmptyList()
+    {
+        this.nutritionRepository
+            .Setup(r => r.GetNutritionPlansForClientAsync(99))
+            .ReturnsAsync(new List<NutritionPlan>());
+
+        var service = this.CreateService();
+        var result = await service.GetPlansForClientAsync(99);
+
+        Assert.Empty(result);
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
+    <ProjectReference Include="..\WebAPI\WebAPI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/WorkoutLogServiceTests.cs
+++ b/Tests/WorkoutLogServiceTests.cs
@@ -1,0 +1,96 @@
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class WorkoutLogServiceTests
+{
+    private readonly Mock<IWorkoutLogRepository> workoutLogRepository = new();
+
+    private WorkoutLogService CreateService() => new(this.workoutLogRepository.Object);
+
+    [Fact]
+    public async Task GetWorkoutHistory_ZeroRating_MapsToNullInDto()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            CreateLogWithRating(rating: 0),
+        };
+
+        this.workoutLogRepository
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        var result = await service.GetWorkoutHistoryAsync(1);
+
+        Assert.Single(result);
+        Assert.Null(result[0].Rating);
+    }
+
+    [Fact]
+    public async Task GetWorkoutHistory_PositiveRating_PreservedInDto()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            CreateLogWithRating(rating: 4.5),
+        };
+
+        this.workoutLogRepository
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        var result = await service.GetWorkoutHistoryAsync(1);
+
+        Assert.Equal(4.5, result[0].Rating);
+    }
+
+    [Fact]
+    public async Task GetWorkoutHistory_NegativeRatingSentinel_MapsToNullInDto()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            CreateLogWithRating(rating: -1),
+        };
+
+        this.workoutLogRepository
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        var result = await service.GetWorkoutHistoryAsync(1);
+
+        Assert.Null(result[0].Rating);
+    }
+
+    [Fact]
+    public async Task GetWorkoutHistory_NoLogs_ReturnsEmptyList()
+    {
+        this.workoutLogRepository
+            .Setup(r => r.GetWorkoutHistoryAsync(999))
+            .ReturnsAsync(new List<WorkoutLog>());
+
+        var service = this.CreateService();
+        var result = await service.GetWorkoutHistoryAsync(999);
+
+        Assert.Empty(result);
+    }
+
+    private static WorkoutLog CreateLogWithRating(double rating)
+    {
+        return new WorkoutLog
+        {
+            WorkoutLogId = 1,
+            Client = new Client { ClientId = 1, Email = "test@test.com", FullName = "Test User" },
+            WorkoutName = "Push Day",
+            Date = DateTime.Today,
+            Duration = TimeSpan.FromMinutes(60),
+            Type = WorkoutType.CUSTOM,
+            Rating = rating,
+            Exercises = new List<LoggedExercise>(),
+        };
+    }
+}

--- a/Tests/WorkoutLogServiceTests.cs
+++ b/Tests/WorkoutLogServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class WorkoutLogServiceTests
         };
 
         this.workoutLogRepository
-            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .Setup(repository => repository.GetWorkoutHistoryAsync(1))
             .ReturnsAsync(logs);
 
         var service = this.CreateService();
@@ -39,7 +39,7 @@ public sealed class WorkoutLogServiceTests
         };
 
         this.workoutLogRepository
-            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .Setup(repository => repository.GetWorkoutHistoryAsync(1))
             .ReturnsAsync(logs);
 
         var service = this.CreateService();
@@ -57,7 +57,7 @@ public sealed class WorkoutLogServiceTests
         };
 
         this.workoutLogRepository
-            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .Setup(repository => repository.GetWorkoutHistoryAsync(1))
             .ReturnsAsync(logs);
 
         var service = this.CreateService();
@@ -70,7 +70,7 @@ public sealed class WorkoutLogServiceTests
     public async Task GetWorkoutHistory_NoLogs_ReturnsEmptyList()
     {
         this.workoutLogRepository
-            .Setup(r => r.GetWorkoutHistoryAsync(999))
+            .Setup(repository => repository.GetWorkoutHistoryAsync(999))
             .ReturnsAsync(new List<WorkoutLog>());
 
         var service = this.CreateService();

--- a/UBB-SE-2026-832-1.sln
+++ b/UBB-SE-2026-832-1.sln
@@ -1,34 +1,76 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI", "WinUI\WinUI.csproj", "{3B267DF1-B41D-4699-B822-7F4252CA6CB8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{33EB627E-B53D-47F6-A71F-988CD5FA9B61}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x64.Build.0 = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x86.Build.0 = Debug|Any CPU
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x64.ActiveCfg = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x64.Build.0 = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x86.ActiveCfg = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x86.Build.0 = Release|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x64.Build.0 = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x86.Build.0 = Debug|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x64.ActiveCfg = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x64.Build.0 = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x86.ActiveCfg = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x86.Build.0 = Release|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x86.Build.0 = Debug|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x64.Build.0 = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x86.Build.0 = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x64.Build.0 = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x86.Build.0 = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x64.ActiveCfg = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x64.Build.0 = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x86.ActiveCfg = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal
-

--- a/UBB-SE-2026-832-1.sln
+++ b/UBB-SE-2026-832-1.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI", "WinUI\WinUI.csproj", "{3B267DF1-B41D-4699-B822-7F4252CA6CB8}"
 EndProject

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -17,6 +17,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMealPlanService, MealPlanService>();
         services.AddScoped<IInventoryService, InventoryService>();
         services.AddScoped<IShoppingListService, ShoppingListService>();
+        services.AddScoped<INutritionPlanService, NutritionPlanService>();
+        services.AddScoped<IWorkoutLogService, WorkoutLogService>();
         return services;
     }
 }

--- a/WebAPI/IServices/INutritionPlanService.cs
+++ b/WebAPI/IServices/INutritionPlanService.cs
@@ -1,0 +1,12 @@
+using ClassLibrary.DTOs;
+
+namespace WebAPI.IServices;
+
+public interface INutritionPlanService
+{
+    Task<NutritionPlanDataTransferObject> CreatePlanAsync(int clientId);
+
+    Task<IReadOnlyList<NutritionPlanDataTransferObject>> GetPlansForClientAsync(int clientId);
+
+    Task AddMealToPlanAsync(int planId, MealDataTransferObject meal);
+}

--- a/WebAPI/IServices/IWorkoutLogService.cs
+++ b/WebAPI/IServices/IWorkoutLogService.cs
@@ -1,0 +1,14 @@
+using ClassLibrary.DTOs;
+
+namespace WebAPI.IServices;
+
+public interface IWorkoutLogService
+{
+    Task<IReadOnlyList<WorkoutLogDataTransferObject>> GetWorkoutHistoryAsync(int clientId);
+
+    Task SaveWorkoutLogAsync(WorkoutLogDataTransferObject workoutLog);
+
+    Task UpdateWorkoutLogAsync(WorkoutLogDataTransferObject workoutLog);
+
+    Task<double> GetClientWeightAsync(int clientId);
+}

--- a/WebAPI/Services/ClientService.cs
+++ b/WebAPI/Services/ClientService.cs
@@ -254,7 +254,7 @@ public sealed class ClientService : IClientService
             TotalCaloriesBurned = log.TotalCaloriesBurned,
             AverageMetabolicEquivalent = log.AverageMetabolicEquivalent,
             IntensityTag = log.IntensityTag,
-            Rating = log.Rating,
+            Rating = log.Rating <= 0 ? null : log.Rating,
             TrainerNotes = log.TrainerNotes,
         };
     }
@@ -373,7 +373,7 @@ public sealed class ClientService : IClientService
             TotalCaloriesBurned = workoutLogDataTransferObject.TotalCaloriesBurned,
             AverageMetabolicEquivalent = workoutLogDataTransferObject.AverageMetabolicEquivalent,
             IntensityTag = workoutLogDataTransferObject.IntensityTag,
-            Rating = workoutLogDataTransferObject.Rating,
+            Rating = workoutLogDataTransferObject.Rating ?? 0,
             TrainerNotes = workoutLogDataTransferObject.TrainerNotes,
         };
 

--- a/WebAPI/Services/NutritionPlanService.cs
+++ b/WebAPI/Services/NutritionPlanService.cs
@@ -1,0 +1,81 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using WebAPI.IServices;
+
+namespace WebAPI.Services;
+
+public sealed class NutritionPlanService : INutritionPlanService
+{
+    private const int DEFAULT_PLAN_DURATION_DAYS = 30;
+
+    private readonly INutritionRepository nutritionRepository;
+
+    public NutritionPlanService(INutritionRepository nutritionRepository)
+    {
+        this.nutritionRepository = nutritionRepository;
+    }
+
+    public async Task<NutritionPlanDataTransferObject> CreatePlanAsync(int clientId)
+    {
+        var plan = new NutritionPlan
+        {
+            StartDate = DateTime.Today,
+            EndDate = DateTime.Today.AddDays(DEFAULT_PLAN_DURATION_DAYS),
+        };
+
+        int planId = await this.nutritionRepository.InsertNutritionPlanAsync(plan);
+        await this.nutritionRepository.AssignNutritionPlanToClientAsync(clientId, planId);
+
+        plan.NutritionPlanId = planId;
+        return MapToDto(plan);
+    }
+
+    public async Task<IReadOnlyList<NutritionPlanDataTransferObject>> GetPlansForClientAsync(int clientId)
+    {
+        var plans = await this.nutritionRepository.GetNutritionPlansForClientAsync(clientId);
+        var results = new List<NutritionPlanDataTransferObject>(plans.Count);
+
+        foreach (var plan in plans)
+        {
+            var meals = plan.Meals;
+            results.Add(MapToDto(plan, meals));
+        }
+
+        return results;
+    }
+
+    public async Task AddMealToPlanAsync(int planId, MealDataTransferObject meal)
+    {
+        var newMeal = new Meal
+        {
+            Name = meal.Name,
+            Ingredients = new List<string>(meal.Ingredients),
+            Instructions = meal.Instructions,
+        };
+
+        await this.nutritionRepository.InsertMealAsync(newMeal, planId);
+    }
+
+    private static NutritionPlanDataTransferObject MapToDto(NutritionPlan plan, IReadOnlyList<Meal>? meals = null)
+    {
+        return new NutritionPlanDataTransferObject
+        {
+            NutritionPlanId = plan.NutritionPlanId,
+            StartDate = plan.StartDate,
+            EndDate = plan.EndDate,
+            Meals = (meals ?? plan.Meals ?? new List<Meal>()).Select(MapMealToDto).ToList(),
+        };
+    }
+
+    private static MealDataTransferObject MapMealToDto(Meal meal)
+    {
+        return new MealDataTransferObject
+        {
+            MealId = meal.MealId,
+            Name = meal.Name,
+            Ingredients = new List<string>(meal.Ingredients),
+            Instructions = meal.Instructions,
+        };
+    }
+}

--- a/WebAPI/Services/WorkoutLogService.cs
+++ b/WebAPI/Services/WorkoutLogService.cs
@@ -1,0 +1,121 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using WebAPI.IServices;
+
+namespace WebAPI.Services;
+
+public sealed class WorkoutLogService : IWorkoutLogService
+{
+    private readonly IWorkoutLogRepository workoutLogRepository;
+
+    public WorkoutLogService(IWorkoutLogRepository workoutLogRepository)
+    {
+        this.workoutLogRepository = workoutLogRepository;
+    }
+
+    public async Task<IReadOnlyList<WorkoutLogDataTransferObject>> GetWorkoutHistoryAsync(int clientId)
+    {
+        var logs = await this.workoutLogRepository.GetWorkoutHistoryAsync(clientId);
+        return logs.Select(MapToDto).ToList();
+    }
+
+    public async Task SaveWorkoutLogAsync(WorkoutLogDataTransferObject workoutLog)
+    {
+        var log = MapToModel(workoutLog);
+        await this.workoutLogRepository.SaveWorkoutLogAsync(log);
+    }
+
+    public async Task UpdateWorkoutLogAsync(WorkoutLogDataTransferObject workoutLog)
+    {
+        var log = MapToModel(workoutLog);
+        await this.workoutLogRepository.UpdateWorkoutLogAsync(log);
+    }
+
+    public async Task<double> GetClientWeightAsync(int clientId)
+    {
+        return await this.workoutLogRepository.GetClientWeightAsync(clientId);
+    }
+
+    private static WorkoutLogDataTransferObject MapToDto(WorkoutLog log)
+    {
+        return new WorkoutLogDataTransferObject
+        {
+            WorkoutLogId = log.WorkoutLogId,
+            Client = new ClientDataTransferObject
+            {
+                ClientId = log.Client?.ClientId ?? 0,
+                Email = log.Client?.Email ?? string.Empty,
+                FullName = log.Client?.FullName ?? string.Empty,
+                Weight = log.Client?.Weight ?? 0,
+                Height = log.Client?.Height ?? 0,
+                PrimaryGoal = log.Client?.PrimaryGoal ?? string.Empty,
+            },
+            WorkoutName = log.WorkoutName,
+            Date = log.Date,
+            Duration = log.Duration,
+            SourceTemplateId = log.SourceTemplateId,
+            Type = log.Type.ToString(),
+            Exercises = log.Exercises.Select(MapExerciseToDto).ToList(),
+            TotalCaloriesBurned = log.TotalCaloriesBurned,
+            AverageMetabolicEquivalent = log.AverageMetabolicEquivalent,
+            IntensityTag = log.IntensityTag,
+            Rating = log.Rating <= 0 ? null : log.Rating,
+            TrainerNotes = log.TrainerNotes,
+        };
+    }
+
+    private static LoggedExerciseDataTransferObject MapExerciseToDto(LoggedExercise exercise)
+    {
+        return new LoggedExerciseDataTransferObject
+        {
+            LoggedExerciseId = exercise.LoggedExerciseId,
+            ExerciseName = exercise.ExerciseName,
+            TargetMuscles = exercise.TargetMuscles.ToString(),
+            Sets = exercise.Sets.Select(MapSetToDto).ToList(),
+            MetabolicEquivalent = exercise.MetabolicEquivalent,
+            ExerciseCaloriesBurned = exercise.ExerciseCaloriesBurned,
+            PerformanceRatio = exercise.PerformanceRatio,
+            IsSystemAdjusted = exercise.IsSystemAdjusted,
+            AdjustmentNote = exercise.AdjustmentNote,
+        };
+    }
+
+    private static LoggedSetDataTransferObject MapSetToDto(LoggedSet set)
+    {
+        return new LoggedSetDataTransferObject
+        {
+            LoggedSetId = set.LoggedSetId,
+            ExerciseName = set.ExerciseName,
+            SetIndex = set.SetIndex,
+            TargetReps = set.TargetReps,
+            ActualReps = set.ActualReps,
+            TargetWeight = set.TargetWeight,
+            ActualWeight = set.ActualWeight,
+            SetNumber = set.SetNumber,
+        };
+    }
+
+    private static WorkoutLog MapToModel(WorkoutLogDataTransferObject dto)
+    {
+        var workoutType = Enum.TryParse<WorkoutType>(dto.Type, ignoreCase: true, out var parsedType)
+            ? parsedType
+            : WorkoutType.CUSTOM;
+
+        return new WorkoutLog
+        {
+            WorkoutLogId = dto.WorkoutLogId,
+            Client = new Client { ClientId = dto.Client?.ClientId ?? 0 },
+            WorkoutName = dto.WorkoutName,
+            Date = dto.Date,
+            Duration = dto.Duration,
+            SourceTemplateId = dto.SourceTemplateId,
+            Type = workoutType,
+            TotalCaloriesBurned = dto.TotalCaloriesBurned,
+            AverageMetabolicEquivalent = dto.AverageMetabolicEquivalent,
+            IntensityTag = dto.IntensityTag,
+            Rating = dto.Rating ?? 0,
+            TrainerNotes = dto.TrainerNotes,
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Added NutritionPlanService that explicitly sets StartDate to today and EndDate to 30 days out when creating a new plan, instead of relying on model property defaults
- Added WorkoutLogService with proper nullable rating handling -- ratings of 0 or negative (legacy -1 sentinel) now map to null in the DTO instead of leaking sentinel values through the API
- Changed WorkoutLogDataTransferObject.Rating from double to double? and updated ClientService mapping accordingly
- Set up xUnit test project with Moq and added 9 unit tests covering date defaults, rating mapping edge cases, and DTO round-trips

Closes #97, closes #98