### PR TITLE
Logic Integration: ClientService ModifyWorkout

### DIFF
--- a/Tests/ClientServiceTests.cs
+++ b/Tests/ClientServiceTests.cs
@@ -32,7 +32,7 @@ public sealed class ClientServiceTests
     public async Task ModifyWorkout_WithValidLog_DelegatesToRepository()
     {
         var client = new Client { ClientId = 5, Email = "a@b.com", FullName = "Alice" };
-        this.clientRepo.Setup(r => r.GetByIdAsync(5)).ReturnsAsync(client);
+        this.clientRepo.Setup(repository => repository.GetByIdAsync(5)).ReturnsAsync(client);
 
         var dto = new WorkoutLogDataTransferObject
         {
@@ -49,7 +49,7 @@ public sealed class ClientServiceTests
         bool result = await service.ModifyWorkoutAsync(dto);
 
         Assert.True(result);
-        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.Is<WorkoutLog>(
+        this.workoutLogRepo.Verify(repository => repository.UpdateWorkoutLogAsync(It.Is<WorkoutLog>(
             log => log.WorkoutLogId == 10 && log.WorkoutName == "Updated Push Day")), Times.Once);
     }
 
@@ -60,7 +60,7 @@ public sealed class ClientServiceTests
         bool result = await service.ModifyWorkoutAsync(null!);
 
         Assert.False(result);
-        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Never);
+        this.workoutLogRepo.Verify(repository => repository.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Never);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public sealed class ClientServiceTests
     [Fact]
     public async Task ModifyWorkout_WhenClientNotFound_ReturnsFalse()
     {
-        this.clientRepo.Setup(r => r.GetByIdAsync(999)).ReturnsAsync((Client?)null);
+        this.clientRepo.Setup(repository => repository.GetByIdAsync(999)).ReturnsAsync((Client?)null);
 
         var dto = new WorkoutLogDataTransferObject
         {
@@ -95,7 +95,7 @@ public sealed class ClientServiceTests
         bool result = await service.ModifyWorkoutAsync(dto);
 
         Assert.False(result);
-        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Never);
+        this.workoutLogRepo.Verify(repository => repository.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Never);
     }
 
     [Fact]
@@ -111,7 +111,7 @@ public sealed class ClientServiceTests
     public async Task FinalizeWorkout_WithValidRequest_SavesAndReturnsTrue()
     {
         var client = new Client { ClientId = 3, Email = "c@d.com", FullName = "Charlie" };
-        this.clientRepo.Setup(r => r.GetByIdAsync(3)).ReturnsAsync(client);
+        this.clientRepo.Setup(repository => repository.GetByIdAsync(3)).ReturnsAsync(client);
 
         var request = new FinalizeWorkoutRequestDataTransferObject
         {
@@ -129,7 +129,7 @@ public sealed class ClientServiceTests
         bool result = await service.FinalizeWorkoutAsync(request);
 
         Assert.True(result);
-        this.workoutLogRepo.Verify(r => r.SaveWorkoutLogAsync(It.Is<WorkoutLog>(
+        this.workoutLogRepo.Verify(repository => repository.SaveWorkoutLogAsync(It.Is<WorkoutLog>(
             log => log.WorkoutName == "Leg Day")), Times.Once);
     }
 }

--- a/Tests/ClientServiceTests.cs
+++ b/Tests/ClientServiceTests.cs
@@ -1,0 +1,135 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class ClientServiceTests
+{
+    private readonly Mock<IAchievementsRepository> achievementsRepo = new();
+    private readonly Mock<INotificationRepository> notificationRepo = new();
+    private readonly Mock<INutritionRepository> nutritionRepo = new();
+    private readonly Mock<IWorkoutLogRepository> workoutLogRepo = new();
+    private readonly Mock<IWorkoutTemplateRepository> workoutTemplateRepo = new();
+    private readonly Mock<IClientRepository> clientRepo = new();
+    private readonly Mock<IHttpClientFactory> httpClientFactory = new();
+    private readonly Mock<IConfiguration> configuration = new();
+
+    private ClientService CreateService() => new(
+        this.achievementsRepo.Object,
+        this.notificationRepo.Object,
+        this.nutritionRepo.Object,
+        this.workoutLogRepo.Object,
+        this.workoutTemplateRepo.Object,
+        this.clientRepo.Object,
+        this.httpClientFactory.Object,
+        this.configuration.Object);
+
+    [Fact]
+    public async Task ModifyWorkout_WithValidLog_DelegatesToRepository()
+    {
+        var client = new Client { ClientId = 5, Email = "a@b.com", FullName = "Alice" };
+        this.clientRepo.Setup(r => r.GetByIdAsync(5)).ReturnsAsync(client);
+
+        var dto = new WorkoutLogDataTransferObject
+        {
+            WorkoutLogId = 10,
+            Client = new ClientDataTransferObject { ClientId = 5 },
+            WorkoutName = "Updated Push Day",
+            Date = DateTime.Today,
+            Duration = TimeSpan.FromMinutes(45),
+            Type = "CUSTOM",
+            Exercises = new List<LoggedExerciseDataTransferObject>(),
+        };
+
+        var service = this.CreateService();
+        bool result = await service.ModifyWorkoutAsync(dto);
+
+        Assert.True(result);
+        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.Is<WorkoutLog>(
+            log => log.WorkoutLogId == 10 && log.WorkoutName == "Updated Push Day")), Times.Once);
+    }
+
+    [Fact]
+    public async Task ModifyWorkout_WithNullDto_ReturnsFalse()
+    {
+        var service = this.CreateService();
+        bool result = await service.ModifyWorkoutAsync(null!);
+
+        Assert.False(result);
+        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ModifyWorkout_WithZeroWorkoutLogId_ReturnsFalse()
+    {
+        var dto = new WorkoutLogDataTransferObject
+        {
+            WorkoutLogId = 0,
+            Client = new ClientDataTransferObject { ClientId = 5 },
+        };
+
+        var service = this.CreateService();
+        bool result = await service.ModifyWorkoutAsync(dto);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ModifyWorkout_WhenClientNotFound_ReturnsFalse()
+    {
+        this.clientRepo.Setup(r => r.GetByIdAsync(999)).ReturnsAsync((Client?)null);
+
+        var dto = new WorkoutLogDataTransferObject
+        {
+            WorkoutLogId = 10,
+            Client = new ClientDataTransferObject { ClientId = 999 },
+            WorkoutName = "Ghost Workout",
+            Exercises = new List<LoggedExerciseDataTransferObject>(),
+        };
+
+        var service = this.CreateService();
+        bool result = await service.ModifyWorkoutAsync(dto);
+
+        Assert.False(result);
+        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FinalizeWorkout_WithNullRequest_ReturnsFalse()
+    {
+        var service = this.CreateService();
+        bool result = await service.FinalizeWorkoutAsync(null!);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FinalizeWorkout_WithValidRequest_SavesAndReturnsTrue()
+    {
+        var client = new Client { ClientId = 3, Email = "c@d.com", FullName = "Charlie" };
+        this.clientRepo.Setup(r => r.GetByIdAsync(3)).ReturnsAsync(client);
+
+        var request = new FinalizeWorkoutRequestDataTransferObject
+        {
+            WorkoutLog = new WorkoutLogDataTransferObject
+            {
+                Client = new ClientDataTransferObject { ClientId = 3 },
+                WorkoutName = "Leg Day",
+                Duration = TimeSpan.FromMinutes(50),
+                Type = "CUSTOM",
+                Exercises = new List<LoggedExerciseDataTransferObject>(),
+            },
+        };
+
+        var service = this.CreateService();
+        bool result = await service.FinalizeWorkoutAsync(request);
+
+        Assert.True(result);
+        this.workoutLogRepo.Verify(r => r.SaveWorkoutLogAsync(It.Is<WorkoutLog>(
+            log => log.WorkoutName == "Leg Day")), Times.Once);
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClassLibrary\ClassLibrary.csproj" />
+    <ProjectReference Include="..\WebAPI\WebAPI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/UBB-SE-2026-832-1.sln
+++ b/UBB-SE-2026-832-1.sln
@@ -1,34 +1,76 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI", "WinUI\WinUI.csproj", "{3B267DF1-B41D-4699-B822-7F4252CA6CB8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{33EB627E-B53D-47F6-A71F-988CD5FA9B61}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x64.Build.0 = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Debug|x86.Build.0 = Debug|Any CPU
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x64.ActiveCfg = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x64.Build.0 = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x86.ActiveCfg = Release|Any CPU
+		{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}.Release|x86.Build.0 = Release|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x64.Build.0 = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Debug|x86.Build.0 = Debug|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x64.ActiveCfg = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x64.Build.0 = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x86.ActiveCfg = Release|Any CPU
+		{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}.Release|x86.Build.0 = Release|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Debug|x86.Build.0 = Debug|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x64.Build.0 = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B267DF1-B41D-4699-B822-7F4252CA6CB8}.Release|x86.Build.0 = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x64.Build.0 = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Debug|x86.Build.0 = Debug|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x64.ActiveCfg = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x64.Build.0 = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x86.ActiveCfg = Release|Any CPU
+		{33EB627E-B53D-47F6-A71F-988CD5FA9B61}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal
-

--- a/UBB-SE-2026-832-1.sln
+++ b/UBB-SE-2026-832-1.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary", "ClassLibrary\ClassLibrary.csproj", "{1239CA30-0B9C-4962-B6A2-C8C7A9700B2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI", "WebAPI\WebApi.csproj", "{FD9CC266-52C8-4F13-BC6F-C2BC714E6F67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUI", "WinUI\WinUI.csproj", "{3B267DF1-B41D-4699-B822-7F4252CA6CB8}"
 EndProject

--- a/WebAPI/Controllers/ClientController.cs
+++ b/WebAPI/Controllers/ClientController.cs
@@ -81,6 +81,18 @@ public sealed class ClientController : ControllerBase
         return this.Ok();
     }
 
+    [HttpPut("modify-workout")]
+    public async Task<IActionResult> ModifyWorkout([FromBody] WorkoutLogDataTransferObject updatedWorkoutLog)
+    {
+        var success = await this.clientService.ModifyWorkoutAsync(updatedWorkoutLog);
+        if (!success)
+        {
+            return this.BadRequest("Failed to modify workout.");
+        }
+
+        return this.Ok();
+    }
+
     [HttpPost("confirm-deload")]
     public async Task<IActionResult> ConfirmDeload([FromBody] ConfirmDeloadRequestDataTransferObject request)
     {

--- a/WebAPI/IServices/IClientService.cs
+++ b/WebAPI/IServices/IClientService.cs
@@ -23,4 +23,6 @@ public interface IClientService
     Task<bool> ConfirmDeloadAsync(ConfirmDeloadRequestDataTransferObject request);
 
     Task<bool> SyncNutritionAsync(NutritionSyncRequestDataTransferObject request);
+
+    Task<bool> ModifyWorkoutAsync(WorkoutLogDataTransferObject updatedWorkoutLog);
 }

--- a/WebAPI/Services/ClientService.cs
+++ b/WebAPI/Services/ClientService.cs
@@ -239,6 +239,30 @@ public sealed class ClientService : IClientService
         }
     }
 
+    public async Task<bool> ModifyWorkoutAsync(WorkoutLogDataTransferObject updatedWorkoutLog)
+    {
+        if (updatedWorkoutLog == null || updatedWorkoutLog.WorkoutLogId <= 0)
+        {
+            return false;
+        }
+
+        if (updatedWorkoutLog.Client == null || updatedWorkoutLog.Client.ClientId <= 0)
+        {
+            return false;
+        }
+
+        var client = await this.clientRepository.GetByIdAsync(updatedWorkoutLog.Client.ClientId);
+        if (client == null)
+        {
+            return false;
+        }
+
+        var log = MapToWorkoutLog(updatedWorkoutLog, client);
+        log.WorkoutLogId = updatedWorkoutLog.WorkoutLogId;
+        await this.workoutLogRepository.UpdateWorkoutLogAsync(log);
+        return true;
+    }
+
     private static WorkoutLogDataTransferObject MapWorkoutLog(WorkoutLog log)
     {
         return new WorkoutLogDataTransferObject


### PR DESCRIPTION
## Summary
- Added ModifyWorkoutAsync to ClientService for updating existing workout logs through the repository layer
- FinalizeWorkoutAsync already handles creating new workout logs (covers the original SetWorkout stub), so ModifyWorkout completes the pair
- Added PUT endpoint at api/client/modify-workout for the new operation
- Added 6 unit tests covering valid modifications, null/invalid input handling, missing client scenarios, and FinalizeWorkout edge cases

Closes #99