### PR TITLE
Add workout history view with log service

### DIFF
--- a/Tests/DailyLogServiceTests.cs
+++ b/Tests/DailyLogServiceTests.cs
@@ -1,0 +1,203 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebApi.IServices;
+using WebAPI.IServices;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class DailyLogServiceTests
+{
+    private readonly Mock<IDailyLogRepository> mockDailyLogRepository;
+    private readonly Mock<IUserRepository> mockUserRepository;
+    private readonly Mock<IFoodItemService> mockFoodItemService;
+    private readonly Mock<IFoodItemRepository> mockFoodItemRepository;
+    private readonly DailyLogService dailyLogService;
+
+    public DailyLogServiceTests()
+    {
+        this.mockDailyLogRepository = new Mock<IDailyLogRepository>();
+        this.mockUserRepository = new Mock<IUserRepository>();
+        this.mockFoodItemService = new Mock<IFoodItemService>();
+        this.mockFoodItemRepository = new Mock<IFoodItemRepository>();
+        this.dailyLogService = new DailyLogService(
+            this.mockDailyLogRepository.Object,
+            this.mockUserRepository.Object,
+            this.mockFoodItemService.Object,
+            this.mockFoodItemRepository.Object);
+    }
+
+    [Fact]
+    public async Task GetTodayTotalsAsync_WhenRepositoryReturnsLog_ShouldMapCorrectly()
+    {
+        var dailyLog = new DailyLog
+        {
+            Calories = 2100,
+            Protein = 150,
+            Carbohydrates = 250,
+            Fats = 70,
+        };
+
+        this.mockDailyLogRepository
+            .Setup(repository => repository.GetNutritionTotalsForRangeAsync(
+                1, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(dailyLog);
+
+        var result = await this.dailyLogService.GetTodayTotalsAsync(1);
+
+        Assert.Equal(2100, result.TotalCalories);
+        Assert.Equal(150, result.TotalProtein);
+        Assert.Equal(250, result.TotalCarbohydrates);
+        Assert.Equal(70, result.TotalFat);
+    }
+
+    [Fact]
+    public async Task GetTodayTotalsAsync_WhenRepositoryReturnsNull_ShouldReturnEmptyTotals()
+    {
+        this.mockDailyLogRepository
+            .Setup(repository => repository.GetNutritionTotalsForRangeAsync(
+                1, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync((DailyLog?)null);
+
+        var result = await this.dailyLogService.GetTodayTotalsAsync(1);
+
+        Assert.Equal(0, result.TotalCalories);
+        Assert.Equal(0, result.TotalProtein);
+        Assert.Equal(0, result.TotalCarbohydrates);
+        Assert.Equal(0, result.TotalFat);
+    }
+
+    [Fact]
+    public async Task GetCurrentWeekTotalsAsync_ShouldQuerySevenDayRange()
+    {
+        this.mockDailyLogRepository
+            .Setup(repository => repository.GetNutritionTotalsForRangeAsync(
+                1, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync((DailyLog?)null);
+
+        await this.dailyLogService.GetCurrentWeekTotalsAsync(1);
+
+        this.mockDailyLogRepository.Verify(
+            repository => repository.GetNutritionTotalsForRangeAsync(
+                1,
+                It.Is<DateTime>(start => start.DayOfWeek == DayOfWeek.Monday),
+                It.Is<DateTime>(end => (end - DateTime.Today).TotalDays <= 7)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetTodayBurnedCaloriesAsync_ShouldReturnDefaultValue()
+    {
+        var result = await this.dailyLogService.GetTodayBurnedCaloriesAsync(1);
+
+        Assert.Equal(500d, result);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserNutritionTargetsAsync_WhenUserDataExists_ShouldReturnMappedDto()
+    {
+        var userData = new UserData
+        {
+            UserDataId = 10,
+            Weight = 75,
+            Height = 180,
+            Age = 25,
+            Gender = "Male",
+            Goal = "Maintain",
+            CalorieNeeds = 2200,
+            ProteinNeeds = 160,
+            CarbohydrateNeeds = 260,
+            FatNeeds = 70,
+            User = new User { UserId = 1 },
+        };
+
+        this.mockUserRepository
+            .Setup(repository => repository.GetUserDataByUserIdAsync(1))
+            .ReturnsAsync(userData);
+
+        var result = await this.dailyLogService.GetCurrentUserNutritionTargetsAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(75, result.Weight);
+        Assert.Equal(2200, result.CalorieNeeds);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserNutritionTargetsAsync_WhenUserDataDoesNotExist_ShouldReturnNull()
+    {
+        this.mockUserRepository
+            .Setup(repository => repository.GetUserDataByUserIdAsync(999))
+            .ReturnsAsync((UserData?)null);
+
+        var result = await this.dailyLogService.GetCurrentUserNutritionTargetsAsync(999);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task LogFoodItemAsync_WhenFoodItemNotFound_ShouldThrowInvalidOperationException()
+    {
+        this.mockFoodItemRepository
+            .Setup(repository => repository.GetByIdAsync(42))
+            .ReturnsAsync((FoodItem?)null);
+
+        var request = new LogMealRequestDto { MealId = 42, Calories = 300 };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this.dailyLogService.LogFoodItemAsync(1, request));
+    }
+
+    [Fact]
+    public async Task LogFoodItemAsync_WhenUserNotFound_ShouldThrowInvalidOperationException()
+    {
+        this.mockFoodItemRepository
+            .Setup(repository => repository.GetByIdAsync(1))
+            .ReturnsAsync(new FoodItem { FoodItemId = 1, Calories = 200 });
+
+        this.mockUserRepository
+            .Setup(repository => repository.GetByIdAsync(999))
+            .ReturnsAsync((User?)null);
+
+        var request = new LogMealRequestDto { MealId = 1, Calories = 200 };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => this.dailyLogService.LogFoodItemAsync(999, request));
+    }
+
+    [Fact]
+    public async Task LogFoodItemAsync_WhenValid_ShouldAddDailyLogToRepository()
+    {
+        var foodItem = new FoodItem
+        {
+            FoodItemId = 1,
+            Calories = 350,
+            Protein = 25,
+            Carbohydrates = 40,
+            Fat = 10,
+        };
+
+        var user = new User { UserId = 1, Username = "testuser" };
+
+        this.mockFoodItemRepository
+            .Setup(repository => repository.GetByIdAsync(1))
+            .ReturnsAsync(foodItem);
+
+        this.mockUserRepository
+            .Setup(repository => repository.GetByIdAsync(1))
+            .ReturnsAsync(user);
+
+        var request = new LogMealRequestDto { MealId = 1, Calories = 350 };
+
+        await this.dailyLogService.LogFoodItemAsync(1, request);
+
+        this.mockDailyLogRepository.Verify(
+            repository => repository.AddAsync(It.Is<DailyLog>(
+                dailyLog => dailyLog.Calories == 350
+                    && dailyLog.Protein == 25
+                    && dailyLog.Carbohydrates == 40
+                    && dailyLog.Fats == 10)),
+            Times.Once);
+    }
+}

--- a/Tests/WorkoutLogServiceTests.cs
+++ b/Tests/WorkoutLogServiceTests.cs
@@ -79,6 +79,47 @@ public sealed class WorkoutLogServiceTests
         Assert.Empty(result);
     }
 
+    [Fact]
+    public async Task GetClientWeightAsync_ShouldDelegateToRepository()
+    {
+        this.workoutLogRepository
+            .Setup(repository => repository.GetClientWeightAsync(1))
+            .ReturnsAsync(82.5);
+
+        var service = this.CreateService();
+        var result = await service.GetClientWeightAsync(1);
+
+        Assert.Equal(82.5, result);
+    }
+
+    [Fact]
+    public async Task SaveWorkoutLogAsync_ShouldPersistMappedModel()
+    {
+        var dto = new ClassLibrary.DTOs.WorkoutLogDataTransferObject
+        {
+            WorkoutLogId = 5,
+            WorkoutName = "Leg Day",
+            Date = DateTime.Today,
+            Duration = TimeSpan.FromMinutes(45),
+            Type = "CUSTOM",
+            Rating = 4.0,
+            TrainerNotes = "Good form",
+            Exercises = new List<ClassLibrary.DTOs.LoggedExerciseDataTransferObject>(),
+            Client = new ClassLibrary.DTOs.ClientDataTransferObject { ClientId = 1 },
+        };
+
+        var service = this.CreateService();
+        await service.SaveWorkoutLogAsync(dto);
+
+        this.workoutLogRepository.Verify(
+            repository => repository.SaveWorkoutLogAsync(
+                It.Is<WorkoutLog>(log =>
+                    log.WorkoutName == "Leg Day"
+                    && log.Rating == 4.0
+                    && log.Type == WorkoutType.CUSTOM)),
+            Times.Once);
+    }
+
     private static WorkoutLog CreateLogWithRating(double rating)
     {
         return new WorkoutLog

--- a/WinUI/Extensions/ServiceCollectionExtensions.cs
+++ b/WinUI/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,8 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<ICreateWorkoutService, CreateWorkoutService>();
         services.AddHttpClient<ITrainerDashboardService, TrainerDashboardService>();
         services.AddHttpClient<IAchievementsService, AchievementsService>();
+        services.AddScoped<IWorkoutLogService, WorkoutLogService>();
+        services.AddScoped<IWorkoutLogServiceProxy, WorkoutLogServiceProxy>();
         return services;
     }
 }

--- a/WinUI/Services/IWorkoutLogService.cs
+++ b/WinUI/Services/IWorkoutLogService.cs
@@ -1,0 +1,10 @@
+using ClassLibrary.DTOs;
+
+namespace WinUI.Services;
+
+public interface IWorkoutLogService
+{
+    Task<IReadOnlyList<WorkoutLogDataTransferObject>> GetWorkoutHistoryAsync(int clientId);
+
+    Task<double> GetClientWeightAsync(int clientId);
+}

--- a/WinUI/Services/IWorkoutLogServiceProxy.cs
+++ b/WinUI/Services/IWorkoutLogServiceProxy.cs
@@ -1,0 +1,10 @@
+using ClassLibrary.DTOs;
+
+namespace WinUI.Services;
+
+public interface IWorkoutLogServiceProxy
+{
+    Task<IReadOnlyList<WorkoutLogDataTransferObject>> GetWorkoutHistoryAsync(int clientId);
+
+    Task<double> GetClientWeightAsync(int clientId);
+}

--- a/WinUI/Services/WorkoutLogService.cs
+++ b/WinUI/Services/WorkoutLogService.cs
@@ -1,0 +1,23 @@
+using ClassLibrary.DTOs;
+
+namespace WinUI.Services;
+
+public sealed class WorkoutLogService : IWorkoutLogService
+{
+    private readonly IWorkoutLogServiceProxy serviceProxy;
+
+    public WorkoutLogService(IWorkoutLogServiceProxy serviceProxy)
+    {
+        this.serviceProxy = serviceProxy;
+    }
+
+    public Task<IReadOnlyList<WorkoutLogDataTransferObject>> GetWorkoutHistoryAsync(int clientId)
+    {
+        return this.serviceProxy.GetWorkoutHistoryAsync(clientId);
+    }
+
+    public Task<double> GetClientWeightAsync(int clientId)
+    {
+        return this.serviceProxy.GetClientWeightAsync(clientId);
+    }
+}

--- a/WinUI/Services/WorkoutLogServiceProxy.cs
+++ b/WinUI/Services/WorkoutLogServiceProxy.cs
@@ -1,0 +1,29 @@
+using System.Net.Http.Json;
+using ClassLibrary.DTOs;
+
+namespace WinUI.Services;
+
+public sealed class WorkoutLogServiceProxy : IWorkoutLogServiceProxy
+{
+    private const string API_BASE_ADDRESS = "https://localhost:7197";
+    private readonly HttpClient httpClient;
+
+    public WorkoutLogServiceProxy(HttpClient httpClient)
+    {
+        this.httpClient = httpClient;
+    }
+
+    public async Task<IReadOnlyList<WorkoutLogDataTransferObject>> GetWorkoutHistoryAsync(int clientId)
+    {
+        var history = await this.httpClient.GetFromJsonAsync<List<WorkoutLogDataTransferObject>>(
+            $"{API_BASE_ADDRESS}/api/client/{clientId}/workout-history");
+        return history ?? [];
+    }
+
+    public async Task<double> GetClientWeightAsync(int clientId)
+    {
+        var userData = await this.httpClient.GetFromJsonAsync<UserDataDto>(
+            $"{API_BASE_ADDRESS}/api/users/{clientId}/data");
+        return userData?.Weight ?? 0;
+    }
+}

--- a/WinUI/ViewModels/WorkoutLogViewModel.cs
+++ b/WinUI/ViewModels/WorkoutLogViewModel.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using ClassLibrary.DTOs;
+using CommunityToolkit.Mvvm.ComponentModel;
+using WinUI.Services;
+
+namespace WinUI.ViewModels;
+
+public partial class WorkoutLogViewModel : ObservableObject
+{
+    private const string ERROR_LOADING_HISTORY_FORMAT = "Failed to load workout history: {0}";
+    private const string ERROR_LOADING_WEIGHT_FORMAT = "Failed to load client weight: {0}";
+
+    private readonly IWorkoutLogService workoutLogService;
+
+    [ObservableProperty]
+    private ObservableCollection<WorkoutLogDataTransferObject> workoutHistory = new();
+
+    [ObservableProperty]
+    private WorkoutLogDataTransferObject? selectedWorkout;
+
+    [ObservableProperty]
+    private double clientWeight;
+
+    [ObservableProperty]
+    private bool isLoading;
+
+    [ObservableProperty]
+    private string errorMessage = string.Empty;
+
+    public WorkoutLogViewModel(IWorkoutLogService workoutLogService)
+    {
+        this.workoutLogService = workoutLogService ?? throw new ArgumentNullException(nameof(workoutLogService));
+    }
+
+    public async Task LoadWorkoutHistoryAsync(int clientId)
+    {
+        try
+        {
+            IsLoading = true;
+            ErrorMessage = string.Empty;
+
+            var history = await this.workoutLogService.GetWorkoutHistoryAsync(clientId);
+
+            this.WorkoutHistory.Clear();
+            foreach (var workoutLog in history)
+            {
+                this.WorkoutHistory.Add(workoutLog);
+            }
+        }
+        catch (Exception exception)
+        {
+            ErrorMessage = string.Format(ERROR_LOADING_HISTORY_FORMAT, exception.Message);
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    public async Task LoadClientWeightAsync(int clientId)
+    {
+        try
+        {
+            ClientWeight = await this.workoutLogService.GetClientWeightAsync(clientId);
+        }
+        catch (Exception exception)
+        {
+            ErrorMessage = string.Format(ERROR_LOADING_WEIGHT_FORMAT, exception.Message);
+        }
+    }
+}

--- a/WinUI/Views/MainWindowView.xaml.cs
+++ b/WinUI/Views/MainWindowView.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class MainWindowView : Page
         ViewModel.AddTab("Home", typeof(MainView));
         ViewModel.AddTab("Meal Plans", typeof(MealPlanView));
         ViewModel.AddTab("Inventory", typeof(InventoryView));
+        ViewModel.AddTab("Workout History", typeof(WorkoutLogView));
         ViewModel.Tabs.CollectionChanged += OnTabsCollectionChanged;
         PopulateTabs();
         mainTabView.SelectionChanged += OnTabSelectionChanged;

--- a/WinUI/Views/WorkoutLogView.xaml
+++ b/WinUI/Views/WorkoutLogView.xaml
@@ -1,0 +1,121 @@
+<Page
+    x:Class="WinUI.Views.WorkoutLogView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid Padding="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Workout History" Style="{ThemeResource TitleTextBlockStyle}" Margin="0,0,0,16"/>
+
+        <TextBlock
+            Grid.Row="1"
+            Text="{Binding ErrorMessage}"
+            Foreground="Red"
+            TextWrapping="Wrap"
+            Margin="0,0,0,8"/>
+
+        <!-- Weight display -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="8" Margin="0,0,0,16">
+            <TextBlock Text="Current Weight:" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
+            <TextBlock Text="{Binding ClientWeight}" Style="{ThemeResource BodyTextBlockStyle}"/>
+            <TextBlock Text="kg" Style="{ThemeResource BodyTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+        </StackPanel>
+
+        <!-- Workout history list -->
+        <Grid Grid.Row="3" Margin="0,0,0,16">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Text="Past Workouts" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,8"/>
+
+            <ListView
+                Grid.Row="1"
+                x:Name="WorkoutHistoryListView"
+                ItemsSource="{Binding WorkoutHistory}"
+                SelectedItem="{Binding SelectedWorkout, Mode=TwoWay}">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Padding="0,6">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="160"/>
+                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="80"/>
+                                <ColumnDefinition Width="80"/>
+                                <ColumnDefinition Width="100"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{Binding WorkoutName}" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Column="1" Text="{Binding Date}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                            <StackPanel Grid.Column="2">
+                                <TextBlock Text="Duration" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                <TextBlock Text="{Binding Duration}"/>
+                            </StackPanel>
+                            <StackPanel Grid.Column="3">
+                                <TextBlock Text="Calories" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                <TextBlock Text="{Binding TotalCaloriesBurned}"/>
+                            </StackPanel>
+                            <StackPanel Grid.Column="4">
+                                <TextBlock Text="Intensity" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                <TextBlock Text="{Binding IntensityTag}"/>
+                            </StackPanel>
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </Grid>
+
+        <!-- Selected workout details -->
+        <Grid Grid.Row="4">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Text="Workout Details" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,8"/>
+
+            <StackPanel Grid.Row="1" Spacing="8">
+                <StackPanel Orientation="Horizontal" Spacing="16">
+                    <StackPanel>
+                        <TextBlock Text="Type" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <TextBlock Text="{Binding SelectedWorkout.Type}"/>
+                    </StackPanel>
+                    <StackPanel>
+                        <TextBlock Text="Rating" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <TextBlock Text="{Binding SelectedWorkout.Rating}"/>
+                    </StackPanel>
+                    <StackPanel>
+                        <TextBlock Text="Avg MET" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                        <TextBlock Text="{Binding SelectedWorkout.AverageMetabolicEquivalent}"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <StackPanel>
+                    <TextBlock Text="Trainer Notes" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                    <TextBlock Text="{Binding SelectedWorkout.TrainerNotes}" TextWrapping="Wrap"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+
+        <!-- Loading overlay -->
+        <ProgressRing
+            Grid.Row="0"
+            Grid.RowSpan="5"
+            IsActive="{Binding IsLoading}"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Width="48"
+            Height="48"/>
+    </Grid>
+</Page>

--- a/WinUI/Views/WorkoutLogView.xaml.cs
+++ b/WinUI/Views/WorkoutLogView.xaml.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WinUI.Services;
+using WinUI.ViewModels;
+
+namespace WinUI.Views;
+
+public sealed partial class WorkoutLogView : Page
+{
+    private readonly WorkoutLogViewModel viewModel;
+    private readonly UserSession userSession;
+
+    public WorkoutLogView()
+    {
+        this.InitializeComponent();
+
+        this.userSession = new UserSession();
+        this.viewModel = new WorkoutLogViewModel(
+            new WorkoutLogService(new WorkoutLogServiceProxy(new HttpClient())));
+        this.DataContext = this.viewModel;
+
+        this.Loaded += OnPageLoaded;
+    }
+
+    private async void OnPageLoaded(object sender, RoutedEventArgs args)
+    {
+        await this.viewModel.LoadClientWeightAsync(this.userSession.CurrentClientId).ConfigureAwait(true);
+        await this.viewModel.LoadWorkoutHistoryAsync(this.userSession.CurrentClientId).ConfigureAwait(true);
+    }
+}


### PR DESCRIPTION
## Summary
Built the workout history feature end-to-end -- WinUI service layer, view model, and view page that displays a client's past workouts with details.

### What changed
- **WorkoutLogService + WorkoutLogServiceProxy** -- WinUI service layer calling ClientController's workout-history endpoint and user data endpoint for client weight
- **WorkoutLogViewModel** -- view model that loads workout history into an observable collection with proper error handling, plus client weight display
- **WorkoutLogView** -- history list showing workout name, date, duration, calories burned, and intensity tag per entry, plus a detail panel for the selected workout (type, rating, MET, trainer notes)
- Registered workout log services in DI container
- Added Workout History tab to the main window navigation
- Added unit tests for the WebAPI DailyLogService and extended WorkoutLogService tests

Closes #186