### PR TITLE
Fix missing DI registrations and wrong AddUserData method call

### DIFF
--- a/Tests/WebApiBugFixTests.cs
+++ b/Tests/WebApiBugFixTests.cs
@@ -1,0 +1,61 @@
+using ClassLibrary.DTOs;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using WebAPI.Controllers;
+using WebAPI.IServices;
+
+namespace Tests;
+
+public class UsersControllerAddUserDataTests
+{
+    private readonly Mock<IUserService> mockUserService;
+    private readonly UsersController controller;
+
+    public UsersControllerAddUserDataTests()
+    {
+        this.mockUserService = new Mock<IUserService>();
+        this.controller = new UsersController(this.mockUserService.Object);
+    }
+
+    [Fact]
+    public async Task AddUserData_ShouldCallAddUserDataAsync_NotUpdate()
+    {
+        var userData = new UserDataDto { UserId = 1 };
+        this.mockUserService.Setup(service => service.AddUserDataAsync(userData))
+            .Returns(Task.CompletedTask);
+
+        var result = await this.controller.AddUserData(userData);
+
+        this.mockUserService.Verify(
+            service => service.AddUserDataAsync(userData), Times.Once);
+        this.mockUserService.Verify(
+            service => service.UpdateUserDataAsync(It.IsAny<UserDataDto>()), Times.Never);
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task AddUserData_ShouldReturnOk_WhenServiceSucceeds()
+    {
+        var userData = new UserDataDto { UserId = 42 };
+        this.mockUserService.Setup(service => service.AddUserDataAsync(userData))
+            .Returns(Task.CompletedTask);
+
+        var result = await this.controller.AddUserData(userData);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public async Task UpdateUserData_ShouldCallUpdateUserDataAsync()
+    {
+        var userData = new UserDataDto { UserId = 1 };
+        this.mockUserService.Setup(service => service.UpdateUserDataAsync(userData))
+            .Returns(Task.CompletedTask);
+
+        var result = await this.controller.UpdateUserData(userData);
+
+        this.mockUserService.Verify(
+            service => service.UpdateUserDataAsync(userData), Times.Once);
+        Assert.IsType<OkResult>(result);
+    }
+}

--- a/WebAPI/Controllers/UsersController.cs
+++ b/WebAPI/Controllers/UsersController.cs
@@ -69,7 +69,7 @@ public sealed class UsersController : ControllerBase
     [HttpPost("data")]
     public async Task<IActionResult> AddUserData([FromBody] ClassLibrary.DTOs.UserDataDto userData)
     {
-        await userService.UpdateUserDataAsync(userData);
+        await userService.AddUserDataAsync(userData);
         return Ok();
     }
 

--- a/WebAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/WebAPI/Extensions/ServiceCollectionExtensions.cs
@@ -31,6 +31,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IDailyLogService, DailyLogService>();
         services.AddScoped<IChatService, ChatService>();
         services.AddScoped<ICalendarWorkoutCatalogService, CalendarWorkoutCatalogService>();
+        services.AddScoped<ITrainerService, TrainerService>();
+        services.AddScoped<ICalendarExportService, CalendarExportService>();
         services.AddSingleton<IAchievementUnlockedBus, AchievementUnlockedBus>();
 
         return services;


### PR DESCRIPTION
﻿## Summary
Fixes two WebAPI bugs that cause runtime failures:

- **Missing DI registrations** for `ITrainerService` and `ICalendarExportService` (#297) -- any request to `TrainerController` or `CalendarExportController` would crash with a DI resolution error.
- **Wrong method call** in `UsersController.AddUserData` (#301) -- the POST endpoint was calling `UpdateUserDataAsync` instead of `AddUserDataAsync`, silently updating existing data instead of inserting new records.

## Changes
- Added `AddScoped` registrations for both missing services
- Fixed the `AddUserData` action to call the correct service method
- Added unit tests verifying the controller calls the right method

## Test plan
- [x] Verify `AddUserData` calls `AddUserDataAsync` (not `UpdateUserDataAsync`)
- [x] Verify `UpdateUserData` still calls `UpdateUserDataAsync`
