### PR TITLE
Standardize WinUI service API base URLs

### DIFF
--- a/WinUI/Extensions/ServiceCollectionExtensions.cs
+++ b/WinUI/Extensions/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<ITrainerDashboardService, TrainerDashboardService>();
         services.AddHttpClient<IAchievementsService, AchievementsService>(client =>
         {
-            client.BaseAddress = new Uri("https://localhost:7197/api/");
+            client.BaseAddress = new Uri($"{ApiBaseUrl.BASE_URL}/api/");
         });
         services.AddScoped<IDailyLogService, DailyLogService>();
         services.AddScoped<IDailyLogServiceProxy, DailyLogServiceProxy>();

--- a/WinUI/Services/AchievementsService.cs
+++ b/WinUI/Services/AchievementsService.cs
@@ -8,7 +8,7 @@ namespace WinUI.Services;
 public sealed class AchievementsService : IAchievementsService
 {
     private readonly HttpClient httpClient;
-    private const string baseAddress = "https://localhost:7197/api";
+    private const string baseAddress = ApiBaseUrl.BASE_URL + "/api";
     private const string clientRoute = "client";
 
     public AchievementsService(HttpClient httpClient)

--- a/WinUI/Services/ActiveWorkoutService.cs
+++ b/WinUI/Services/ActiveWorkoutService.cs
@@ -7,7 +7,7 @@ namespace WinUI.Services;
 public sealed class ActiveWorkoutService : IActiveWorkoutService
 {
     private readonly HttpClient httpClient;
-    private const string baseAddress = "https://localhost:7197/api";
+    private const string baseAddress = ApiBaseUrl.BASE_URL + "/api";
     private const string clientRoute = baseAddress + "/client";
 
     public ActiveWorkoutService(HttpClient httpClient)

--- a/WinUI/Services/CalendarIntegrationService.cs
+++ b/WinUI/Services/CalendarIntegrationService.cs
@@ -25,7 +25,7 @@ public interface ICalendarIntegrationService
 public sealed class CalendarIntegrationService : ICalendarIntegrationService
 {
     private readonly HttpClient httpClient;
-    private const string apiBaseAddress = "https://localhost:7197";
+    private const string apiBaseAddress = ApiBaseUrl.BASE_URL;
     private const string clientRoutePrefix = "api/client";
 
     public CalendarIntegrationService(HttpClient httpClient)

--- a/WinUI/Services/CreateWorkoutService.cs
+++ b/WinUI/Services/CreateWorkoutService.cs
@@ -7,7 +7,7 @@ namespace WinUI.Services;
 public sealed class CreateWorkoutService : ICreateWorkoutService
 {
     private readonly HttpClient httpClient;
-    private const string ApiUrl = "https://localhost:7197/api";
+    private const string ApiUrl = ApiBaseUrl.BASE_URL + "/api";
     private const string Route = "trainer";
 
     public CreateWorkoutService(HttpClient httpClient)

--- a/WinUI/Services/ShoppingListService.cs
+++ b/WinUI/Services/ShoppingListService.cs
@@ -6,7 +6,7 @@ namespace WinUI.Services;
 
 public sealed class ShoppingListService : IShoppingListService
 {
-    private const string API_BASE_ADDRESS = "https://localhost:7197/api";
+    private const string API_BASE_ADDRESS = ApiBaseUrl.BASE_URL + "/api";
     private const string SHOPPING_LIST_ROUTE = "ShoppingList";
     private readonly HttpClient httpClient;
 

--- a/WinUI/Services/TrainerDashboardService.cs
+++ b/WinUI/Services/TrainerDashboardService.cs
@@ -7,7 +7,7 @@ namespace WinUI.Services;
 public sealed class TrainerDashboardService : ITrainerDashboardService
 {
     private readonly HttpClient httpClient;
-    private const string baseAddress = "https://localhost:7197/api";
+    private const string baseAddress = ApiBaseUrl.BASE_URL + "/api";
     private const string trainerRoute = "trainer";
 
     public TrainerDashboardService(HttpClient httpClient)


### PR DESCRIPTION
﻿## Summary
Standardizes all WinUI service API base URLs to use the centralized `ApiBaseUrl.BASE_URL` constant (#298).

Six services were hardcoding `https://localhost:7197` which does not match the WebAPI's `launchSettings.json` (`http://localhost:5066`). This meant those services would fail to connect to the backend at runtime.

## Changes
Replaced hardcoded `https://localhost:7197` in:
- `ActiveWorkoutService`  
- `AchievementsService`  
- `CalendarIntegrationService`  
- `CreateWorkoutService`  
- `ShoppingListService`  
- `TrainerDashboardService`  
- `ServiceCollectionExtensions` (HttpClient `BaseAddress`)

All now reference `ApiBaseUrl.BASE_URL` (`http://localhost:5066`).

## Test plan
- [x] Grep confirms zero remaining `7197` references in WinUI
- [ ] Verify services connect to WebAPI at runtime
