### PR TITLE
Fix UserView binding and AchievementsViewModel interface mismatch

### DIFF
--- a/Tests/AchievementsViewModelTests.cs
+++ b/Tests/AchievementsViewModelTests.cs
@@ -1,0 +1,99 @@
+using ClassLibrary.Models;
+using Moq;
+using WinUI.Services;
+using WinUI.ViewModels;
+
+namespace Tests;
+
+public class AchievementsViewModelTests
+{
+    private readonly Mock<IAchievementsService> mockAchievementsService;
+    private readonly AchievementsViewModel viewModel;
+
+    public AchievementsViewModelTests()
+    {
+        this.mockAchievementsService = new Mock<IAchievementsService>();
+        this.viewModel = new AchievementsViewModel(this.mockAchievementsService.Object);
+    }
+
+    [Fact]
+    public async Task LoadAchievements_ShouldPopulateCollection_WhenServiceReturnsItems()
+    {
+        var expectedAchievements = new List<Achievement>
+        {
+            new Achievement { AchievementId = 1, Name = "First Workout" },
+            new Achievement { AchievementId = 2, Name = "Week Streak" },
+        };
+        this.mockAchievementsService
+            .Setup(service => service.GetAchievementsAsync(1))
+            .ReturnsAsync(expectedAchievements);
+
+        await this.viewModel.LoadAchievementsCommand.ExecuteAsync(1);
+
+        Assert.Equal(2, this.viewModel.Achievements.Count);
+        Assert.Equal("First Workout", this.viewModel.Achievements[0].Name);
+        Assert.Equal("Week Streak", this.viewModel.Achievements[1].Name);
+    }
+
+    [Fact]
+    public async Task LoadAchievements_ShouldResultInEmptyCollection_WhenServiceReturnsEmpty()
+    {
+        this.mockAchievementsService
+            .Setup(service => service.GetAchievementsAsync(1))
+            .ReturnsAsync(new List<Achievement>());
+
+        await this.viewModel.LoadAchievementsCommand.ExecuteAsync(1);
+
+        Assert.Empty(this.viewModel.Achievements);
+    }
+
+    [Fact]
+    public async Task LoadAchievements_ShouldSetIsLoadingFalse_AfterCompletion()
+    {
+        this.mockAchievementsService
+            .Setup(service => service.GetAchievementsAsync(1))
+            .ReturnsAsync(new List<Achievement>());
+
+        await this.viewModel.LoadAchievementsCommand.ExecuteAsync(1);
+
+        Assert.False(this.viewModel.IsLoading);
+    }
+
+    [Fact]
+    public async Task LoadAchievements_ShouldClearPreviousItems_BeforeLoading()
+    {
+        var firstBatch = new List<Achievement>
+        {
+            new Achievement { AchievementId = 1, Name = "Old" },
+        };
+        var secondBatch = new List<Achievement>
+        {
+            new Achievement { AchievementId = 2, Name = "New" },
+        };
+
+        this.mockAchievementsService
+            .SetupSequence(service => service.GetAchievementsAsync(1))
+            .ReturnsAsync(firstBatch)
+            .ReturnsAsync(secondBatch);
+
+        await this.viewModel.LoadAchievementsCommand.ExecuteAsync(1);
+        await this.viewModel.LoadAchievementsCommand.ExecuteAsync(1);
+
+        Assert.Single(this.viewModel.Achievements);
+        Assert.Equal("New", this.viewModel.Achievements[0].Name);
+    }
+
+    [Fact]
+    public async Task LoadAchievements_ShouldSetIsLoadingFalse_WhenServiceThrows()
+    {
+        this.mockAchievementsService
+            .Setup(service => service.GetAchievementsAsync(1))
+            .ThrowsAsync(new HttpRequestException("Network error"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => this.viewModel.LoadAchievementsCommand.ExecuteAsync(1));
+
+        Assert.False(this.viewModel.IsLoading);
+        Assert.Empty(this.viewModel.Achievements);
+    }
+}

--- a/WinUI/Services/IAchievementService.cs
+++ b/WinUI/Services/IAchievementService.cs
@@ -1,8 +1,0 @@
-﻿using ClassLibrary.Models;
-
-namespace WinUI.Services.Interfaces;
-
-public interface IAchievementService
-{
-    Task<List<Achievement>> GetAchievementsAsync(int clientId, CancellationToken cancellationToken = default);
-}

--- a/WinUI/ViewModels/AchievementsViewModel.cs
+++ b/WinUI/ViewModels/AchievementsViewModel.cs
@@ -2,13 +2,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ClassLibrary.Models;
-using WinUI.Services.Interfaces;
+using WinUI.Services;
 
 namespace WinUI.ViewModels;
 
 public sealed partial class AchievementsViewModel : ObservableObject
 {
-    private readonly IAchievementService achievementService;
+    private readonly IAchievementsService achievementsService;
 
     [ObservableProperty]
     private ObservableCollection<Achievement> achievements;
@@ -16,9 +16,9 @@ public sealed partial class AchievementsViewModel : ObservableObject
     [ObservableProperty]
     private bool isLoading;
 
-    public AchievementsViewModel(IAchievementService achievementService)
+    public AchievementsViewModel(IAchievementsService achievementsService)
     {
-        this.achievementService = achievementService;
+        this.achievementsService = achievementsService;
         this.achievements = new ObservableCollection<Achievement>();
     }
 
@@ -30,7 +30,7 @@ public sealed partial class AchievementsViewModel : ObservableObject
         try
         {
             Achievements.Clear();
-            var result = await achievementService.GetAchievementsAsync(clientId);
+            var result = await achievementsService.GetAchievementsAsync(clientId);
 
             foreach (var achievement in result)
             {

--- a/WinUI/Views/UserView.xaml
+++ b/WinUI/Views/UserView.xaml
@@ -28,7 +28,7 @@
                 <StackPanel Spacing="12" MaxWidth="400" HorizontalAlignment="Left" Margin="0,16,0,0">
                     <TextBox
                         Header="Username"
-                        Text="{Binding Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Text="{Binding UserName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                         PlaceholderText="Enter your username"/>
 
                     <PasswordBox
@@ -49,7 +49,7 @@
                     <StackPanel Spacing="12" MaxWidth="400" HorizontalAlignment="Left" Margin="0,16,0,0">
                         <TextBox
                             Header="Username"
-                            Text="{Binding Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            Text="{Binding UserName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                             PlaceholderText="Choose a username"/>
 
                         <PasswordBox


### PR DESCRIPTION
﻿## Summary
Fixes two WinUI bugs that cause blank/broken UI:

- **UserView.xaml** (#299) -- login and register TextBoxes bound to `Username` but the ViewModel exposes `UserName` (generated by `[ObservableProperty]` on `userName` field). Both bindings now use the correct casing.
- **AchievementsViewModel** (#300) -- depended on `IAchievementService` (singular), which had no implementation. The actual implementation (`AchievementsService`) implements `IAchievementsService` (plural). Updated the ViewModel to use the correct interface and removed the orphaned `IAchievementService.cs`.

## Changes
- Fixed 2 binding paths in `UserView.xaml` (`Username` to `UserName`)
- Switched `AchievementsViewModel` from `IAchievementService` to `IAchievementsService`  
- Deleted unused `IAchievementService.cs`  
- Added 5 unit tests for `AchievementsViewModel`  

## Test plan
- [x] `AchievementsViewModel` loads items through `IAchievementsService`  
- [x] Empty list handling  
- [x] Previous items cleared on reload  
- [x] `IsLoading` set correctly on success and failure  
- [ ] UserView login/register fields bind correctly at runtime
