### PR TITLE
Fix pantry ingredient save by using explicit FK properties

### DIFF
--- a/ClassLibrary/Models/Inventory.cs
+++ b/ClassLibrary/Models/Inventory.cs
@@ -4,7 +4,11 @@ public sealed class Inventory
 {
     public int InventoryId { get; set; }
 
+    public int UserId { get; set; }
+
     public User User { get; set; } = default!;
+
+    public int IngredientId { get; set; }
 
     public Ingredient Ingredient { get; set; } = default!;
 

--- a/ClassLibrary/Repositories/InventoryRepository.cs
+++ b/ClassLibrary/Repositories/InventoryRepository.cs
@@ -21,7 +21,7 @@ public sealed class InventoryRepository : IInventoryRepository
         return await this.databaseContext.Inventories
             .AsNoTracking()
             .Include(inventory => inventory.Ingredient)
-            .Where(inventory => EF.Property<int>(inventory, "UserId") == userId)
+            .Where(inventory => inventory.UserId == userId)
             .ToListAsync();
     }
 
@@ -30,21 +30,18 @@ public sealed class InventoryRepository : IInventoryRepository
         return await this.databaseContext.Inventories
             .FirstOrDefaultAsync(
                 existingInventory =>
-                    EF.Property<int>(existingInventory, "UserId") == userId &&
-                    EF.Property<int>(existingInventory, "IngredientId") == ingredientId);
+                    existingInventory.UserId == userId &&
+                    existingInventory.IngredientId == ingredientId);
     }
 
     public async Task AddAsync(Inventory inventory)
     {
-        var userId = inventory.User?.UserId ?? 0;
-        var ingredientId = inventory.Ingredient?.IngredientId ?? 0;
-
-        if (userId <= 0 || ingredientId <= 0)
+        if (inventory.UserId <= 0 || inventory.IngredientId <= 0)
         {
-            throw new ArgumentException("Inventory must include User and Ingredient navigation stubs with valid key values.");
+            throw new ArgumentException("Inventory must have valid UserId and IngredientId.");
         }
 
-        var existing = await this.GetByUserIdAndIngredientIdAsync(userId, ingredientId);
+        var existing = await this.GetByUserIdAndIngredientIdAsync(inventory.UserId, inventory.IngredientId);
         if (existing is not null)
         {
             existing.QuantityGrams += inventory.QuantityGrams;

--- a/Tests/InventoryServiceTests.cs
+++ b/Tests/InventoryServiceTests.cs
@@ -1,0 +1,95 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class InventoryServiceTests
+{
+    private readonly Mock<IIngredientRepository> ingredientRepo = new();
+    private readonly Mock<IInventoryRepository> inventoryRepo = new();
+    private readonly Mock<IMealPlanRepository> mealPlanRepo = new();
+
+    private InventoryService CreateService() => new(
+        this.ingredientRepo.Object,
+        this.inventoryRepo.Object,
+        this.mealPlanRepo.Object);
+
+    [Fact]
+    public async Task AddToPantryAsync_SetsUserIdDirectly()
+    {
+        var request = new AddToPantryRequestDataTransferObject
+        {
+            UserId = 7,
+            IngredientId = 42,
+            QuantityGrams = 250,
+        };
+
+        Inventory? captured = null;
+        this.inventoryRepo
+            .Setup(repo => repo.AddAsync(It.IsAny<Inventory>()))
+            .Callback<Inventory>(inv => captured = inv);
+
+        var service = this.CreateService();
+        await service.AddToPantryAsync(request);
+
+        Assert.NotNull(captured);
+        Assert.Equal(7, captured.UserId);
+        Assert.Equal(42, captured.IngredientId);
+        Assert.Equal(250, captured.QuantityGrams);
+        Assert.Null(captured.User);
+        Assert.Null(captured.Ingredient);
+    }
+
+    [Fact]
+    public async Task AddToPantryAsync_DoesNotCreateStubNavigationEntities()
+    {
+        var request = new AddToPantryRequestDataTransferObject
+        {
+            UserId = 1,
+            IngredientId = 10,
+            QuantityGrams = 100,
+        };
+
+        Inventory? captured = null;
+        this.inventoryRepo
+            .Setup(repo => repo.AddAsync(It.IsAny<Inventory>()))
+            .Callback<Inventory>(inv => captured = inv);
+
+        var service = this.CreateService();
+        await service.AddToPantryAsync(request);
+
+        Assert.NotNull(captured);
+        Assert.Null(captured.User);
+        Assert.Null(captured.Ingredient);
+    }
+
+    [Fact]
+    public async Task AddIngredientByNameToPantryAsync_ResolvesIngredientIdAndDelegates()
+    {
+        this.ingredientRepo
+            .Setup(repo => repo.GetOrCreateIngredientIdByNameAsync("Chicken"))
+            .ReturnsAsync(55);
+
+        Inventory? captured = null;
+        this.inventoryRepo
+            .Setup(repo => repo.AddAsync(It.IsAny<Inventory>()))
+            .Callback<Inventory>(inv => captured = inv);
+
+        var request = new AddIngredientByNameRequestDataTransferObject
+        {
+            UserId = 3,
+            IngredientName = "Chicken",
+        };
+
+        var service = this.CreateService();
+        await service.AddIngredientByNameToPantryAsync(request);
+
+        Assert.NotNull(captured);
+        Assert.Equal(3, captured.UserId);
+        Assert.Equal(55, captured.IngredientId);
+        Assert.Equal(100, captured.QuantityGrams);
+    }
+}

--- a/WebAPI/Services/InventoryService.cs
+++ b/WebAPI/Services/InventoryService.cs
@@ -86,8 +86,8 @@ public sealed class InventoryService : IInventoryService
     {
         var newItem = new Inventory
         {
-            User = new User { UserId = request.UserId },
-            Ingredient = new Ingredient { IngredientId = request.IngredientId },
+            UserId = request.UserId,
+            IngredientId = request.IngredientId,
             QuantityGrams = request.QuantityGrams,
         };
 

--- a/WebAPI/Services/ShoppingListService.cs
+++ b/WebAPI/Services/ShoppingListService.cs
@@ -118,8 +118,8 @@ namespace WebAPI.Services
 
             await inventoryRepository.AddAsync(new Inventory
             {
-                User = new User { UserId = userId },
-                Ingredient = new Ingredient { IngredientId = item.Ingredient.IngredientId },
+                UserId = userId,
+                IngredientId = item.Ingredient.IngredientId,
                 QuantityGrams = item.QuantityGrams > 0 ? (int)item.QuantityGrams : 100
             });
 


### PR DESCRIPTION
﻿## Summary
- Added explicit UserId and IngredientId FK properties to the Inventory model so EF Core no longer tries to INSERT stub navigation entities when saving a new pantry item
- Updated InventoryService.AddToPantryAsync and ShoppingListService.MoveToPantryAsync to set FK values directly
- Cleaned up InventoryRepository queries to use the new FK properties instead of shadow property access

## Test plan
- [x] Verify new pantry items are inserted without PK violations on User/Ingredient tables
- [x] Verify duplicate (user, ingredient) pairs still upsert quantity correctly
- [x] Unit tests for AddToPantryAsync and AddIngredientByNameToPantryAsync confirm no stub entities are created

Closes #274
