### PR TITLE
Fix DailyMealPlanView blank item rendering

### DIFF
--- a/Tests/DailyMealPlanViewModelTests.cs
+++ b/Tests/DailyMealPlanViewModelTests.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+
+namespace Tests;
+
+public sealed class DailyMealPlanBindingTests
+{
+    [Fact]
+    public void StringType_HasNoNameProperty_ExplainingBlankRendering()
+    {
+        PropertyInfo? nameProperty = typeof(string).GetProperty("Name");
+
+        Assert.Null(nameProperty);
+    }
+
+    [Fact]
+    public void StringType_ToStringReturnsValue_SupportingDirectBinding()
+    {
+        const string mealText = "Desayuno: Avena con frutas";
+
+        Assert.Equal(mealText, mealText.ToString());
+    }
+}

--- a/WinUI/Views/DailyMealPlanView.xaml
+++ b/WinUI/Views/DailyMealPlanView.xaml
@@ -14,7 +14,7 @@
 			<ListView ItemsSource="{x:Bind ViewModel.PlannedMeals, Mode=OneWay}">
 				<ListView.ItemTemplate>
 					<DataTemplate>
-						<TextBlock Text="{Binding Name}" />
+						<TextBlock Text="{Binding}" />
 					</DataTemplate>
 				</ListView.ItemTemplate>
 			</ListView>


### PR DESCRIPTION
﻿## Summary
- Fixed `DailyMealPlanView.xaml` item template binding from `{Binding Name}` to `{Binding}` since `PlannedMeals` is an `ObservableCollection<string>` and `string` has no `Name` property
- Meal plan items were rendering blank because the binding path resolved to nothing

## Test plan
- [x] Verify meal plan items display their text correctly in the list
- [x] Reflection test confirms `string` has no `Name` property

Closes #303
