### PR TITLE
Reorganize CalendarIntegration services and fix visibility issue

### DIFF
--- a/WinUI/Services/CalendarExportService.cs
+++ b/WinUI/Services/CalendarExportService.cs
@@ -1,8 +1,8 @@
 using System.Text;
 using ClassLibrary.Models;
-using WinUI.Services.CalendarIntegration.Interfaces;
+using WinUI.Services.Interfaces;
 
-namespace WinUI.Services.CalendarIntegration;
+namespace WinUI.Services;
 
 public sealed class CalendarExportService : ICalendarExportService
 {

--- a/WinUI/Services/CalendarWorkoutCatalogService.cs
+++ b/WinUI/Services/CalendarWorkoutCatalogService.cs
@@ -1,9 +1,9 @@
 using System.Net.Http.Json;
 using ClassLibrary.DTOs;
 using ClassLibrary.Models;
-using WinUI.Services.CalendarIntegration.Interfaces;
+using WinUI.Services.Interfaces;
 
-namespace WinUI.Services.CalendarIntegration;
+namespace WinUI.Services;
 
 public sealed class CalendarWorkoutCatalogService : ICalendarWorkoutCatalogService
 {

--- a/WinUI/Services/Interfaces/ICalendarExportService.cs
+++ b/WinUI/Services/Interfaces/ICalendarExportService.cs
@@ -1,6 +1,6 @@
 using ClassLibrary.Models;
 
-namespace WinUI.Services.CalendarIntegration.Interfaces;
+namespace WinUI.Services.Interfaces;
 
 public interface ICalendarExportService
 {

--- a/WinUI/Services/Interfaces/ICalendarWorkoutCatalogService.cs
+++ b/WinUI/Services/Interfaces/ICalendarWorkoutCatalogService.cs
@@ -1,6 +1,6 @@
 using ClassLibrary.Models;
 
-namespace WinUI.Services.CalendarIntegration.Interfaces;
+namespace WinUI.Services.Interfaces;
 
 public interface ICalendarWorkoutCatalogService
 {

--- a/WinUI/ViewModels/CalendarIntegration/CalendarIntegrationViewModel.cs
+++ b/WinUI/ViewModels/CalendarIntegration/CalendarIntegrationViewModel.cs
@@ -3,7 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using ClassLibrary.Models;
 using Microsoft.UI.Xaml.Controls;
 using WinUI.Services;
-using WinUI.Services.CalendarIntegration.Interfaces;
+using WinUI.Services.Interfaces;
 
 namespace WinUI.ViewModels.CalendarIntegration;
 

--- a/WinUI/Views/CalendarIntegration/CalendarIntegrationPage.xaml.cs
+++ b/WinUI/Views/CalendarIntegration/CalendarIntegrationPage.xaml.cs
@@ -2,7 +2,6 @@ using System.Runtime.InteropServices;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WinUI.Services;
-using WinUI.Services.CalendarIntegration;
 using WinUI.ViewModels.CalendarIntegration;
 using Windows.Storage.Pickers;
 

--- a/WinUITests/CalendarIntegrationTests.cs
+++ b/WinUITests/CalendarIntegrationTests.cs
@@ -1,7 +1,6 @@
 using ClassLibrary.Models;
 using WinUI.Services;
-using WinUI.Services.CalendarIntegration;
-using WinUI.Services.CalendarIntegration.Interfaces;
+using WinUI.Services.Interfaces;
 using WinUI.ViewModels.CalendarIntegration;
 using WinUserSession = WinUI.Services.UserSession;
 


### PR DESCRIPTION
Move CalendarExportService and CalendarWorkoutCatalogService from subfolder to Services root
Update all namespace references 
UserSession IsClient property now correctly returns true for client users, to fix visibility