### PR TITLE
fix: use shared API base URL and clean up duplicate DI registration

### DIFF
--- a/WinUI/Extensions/ServiceCollectionExtensions.cs
+++ b/WinUI/Extensions/ServiceCollectionExtensions.cs
@@ -16,10 +16,6 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<ITrainerDashboardService, TrainerDashboardService>();
         services.AddHttpClient<IAchievementsService, AchievementsService>();
         services.AddHttpClient<IRankShowcaseService, RankShowcaseService>();
-        services.AddHttpClient<IAchievementsService, AchievementsService>(client =>
-        {
-            client.BaseAddress = new Uri($"{ApiBaseUrl.BASE_URL}/api/");
-        });
         services.AddHttpClient<IMealPlanService, MealPlanService>();
         services.AddScoped<IDailyLogService, DailyLogService>();
         services.AddScoped<IDailyLogServiceProxy, DailyLogServiceProxy>();

--- a/WinUI/Services/RankShowcaseService.cs
+++ b/WinUI/Services/RankShowcaseService.cs
@@ -6,7 +6,7 @@ namespace WinUI.Services;
 
 public sealed class RankShowcaseService : IRankShowcaseService
 {
-    private const string ApiBaseAddress = "https://localhost:7197/api";
+    private const string ApiBaseAddress = ApiBaseUrl.BASE_URL + "/api";
     private const string EvaluationRoute = "evaluation";
     private readonly HttpClient httpClient;
 

--- a/WinUI/Services/UserService.cs
+++ b/WinUI/Services/UserService.cs
@@ -14,13 +14,13 @@ public sealed class UserService : IUserService
 
     public UserService()
     {
-        this.httpClient = new HttpClient { BaseAddress = new Uri("http://localhost:5000/") };
+        this.httpClient = new HttpClient { BaseAddress = new Uri(ApiBaseUrl.BASE_URL + "/") };
     }
 
     public UserService(IUserServiceProxy serviceProxy)
     {
         this.legacyProxy = serviceProxy;
-        this.httpClient = new HttpClient { BaseAddress = new Uri("http://localhost:5000/") };
+        this.httpClient = new HttpClient { BaseAddress = new Uri(ApiBaseUrl.BASE_URL + "/") };
     }
 
     public async Task<IReadOnlyList<UserDto>> GetUsersAsync()


### PR DESCRIPTION
## Summary

Fixes two services that were hardcoding their own API base URLs instead of using the shared `ApiBaseUrl.BASE_URL` constant, and removes a duplicate DI registration.

- `RankShowcaseService` was pointing at `https://localhost:7197/api` instead of the shared base URL
- `UserService` was using `http://localhost:5000/` as its `HttpClient.BaseAddress` — both constructors now use `ApiBaseUrl.BASE_URL`
- `ServiceCollectionExtensions` had `IAchievementsService` registered twice via `AddHttpClient` (the second one set a `BaseAddress` lambda that's redundant since `AchievementsService` already builds its own URL from the constant)

Regarding #300: the singular vs plural naming mismatch (`IAchievementService` vs `IAchievementsService`) was already resolved in the latest merge — everything now consistently uses the plural form.

Closes #298
Closes #300
