### PR TITLE
port evaluation engine and progression service tests from vibecoders

### DIFF
--- a/Tests/EvaluationEngineServiceTests.cs
+++ b/Tests/EvaluationEngineServiceTests.cs
@@ -1,0 +1,129 @@
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class EvaluationEngineServiceTests
+{
+    private readonly Mock<IAchievementsRepository> achievementsRepo = new();
+
+    private EvaluationEngineService CreateService() => new(this.achievementsRepo.Object);
+
+    [Fact]
+    public async Task EvaluateAsync_AllAchievementsAlreadyUnlocked_ReturnsEmptyList()
+    {
+        var showcase = new List<AchievementShowcaseItem>
+        {
+            new() { AchievementId = 1, Title = "3-Day Streak", IsUnlocked = true },
+            new() { AchievementId = 2, Title = "Iron Week", IsUnlocked = true },
+        };
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.EvaluateAsync(1);
+
+        Assert.Empty(result);
+
+        this.achievementsRepo.Verify(
+            r => r.AwardAchievementAsync(It.IsAny<int>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_EmptyShowcase_ReturnsEmptyList()
+    {
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(new List<AchievementShowcaseItem>());
+
+        var service = this.CreateService();
+        var result = await service.EvaluateAsync(1);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task BuildRankShowcaseAsync_NoAchievementsUnlocked_ReturnsLevel1()
+    {
+        var showcase = new List<AchievementShowcaseItem>
+        {
+            new() { Title = "Test", IsUnlocked = false },
+        };
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.BuildRankShowcaseAsync(1);
+
+        Assert.Equal(1, result.DisplayLevel);
+        Assert.Equal("0 achievements unlocked", result.UnlockedAchievementsDisplay);
+        Assert.True(result.HasNextRank);
+    }
+
+    [Fact]
+    public async Task BuildRankShowcaseAsync_OneAchievementUnlocked_UsesSingularForm()
+    {
+        var showcase = new List<AchievementShowcaseItem>
+        {
+            new() { Title = "First Step", IsUnlocked = true },
+            new() { Title = "Locked One", IsUnlocked = false },
+        };
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.BuildRankShowcaseAsync(1);
+
+        Assert.Equal("1 achievement unlocked", result.UnlockedAchievementsDisplay);
+    }
+
+    [Fact]
+    public async Task BuildRankShowcaseAsync_NineUnlocked_ProgressIsAboveZero()
+    {
+        var showcase = new List<AchievementShowcaseItem>();
+        for (int i = 0; i < 9; i++)
+        {
+            showcase.Add(new AchievementShowcaseItem { IsUnlocked = true });
+        }
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.BuildRankShowcaseAsync(1);
+
+        Assert.NotNull(result);
+        Assert.True(result.ProgressPercent > 0);
+        Assert.Contains("more achievement", result.NextRankInfo);
+    }
+
+    [Fact]
+    public async Task BuildRankShowcaseAsync_MaxAchievements_ProgressIs100()
+    {
+        var showcase = new List<AchievementShowcaseItem>();
+        for (int i = 0; i < 10; i++)
+        {
+            showcase.Add(new AchievementShowcaseItem { IsUnlocked = true });
+        }
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.BuildRankShowcaseAsync(1);
+
+        Assert.Equal(100, result.ProgressPercent);
+        Assert.False(result.HasNextRank);
+    }
+}

--- a/Tests/EvaluationEngineServiceTests.cs
+++ b/Tests/EvaluationEngineServiceTests.cs
@@ -126,4 +126,69 @@ public sealed class EvaluationEngineServiceTests
         Assert.Equal(100, result.ProgressPercent);
         Assert.False(result.HasNextRank);
     }
+
+    [Fact]
+    public async Task EvaluateAsync_AchievementNotInMilestoneList_IsIgnored()
+    {
+        // titles that don't match any IMilestoneCheck get skipped via TryGetValue miss
+        var showcase = new List<AchievementShowcaseItem>
+        {
+            new() { AchievementId = 99, Title = "Nonexistent Badge", IsUnlocked = false },
+        };
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(42))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.EvaluateAsync(42);
+
+        Assert.Empty(result);
+        this.achievementsRepo.Verify(
+            r => r.AwardAchievementAsync(It.IsAny<int>(), It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Showcase_should_map_unlock_icon_correctly()
+    {
+        var showcase = new List<AchievementShowcaseItem>
+        {
+            new() { AchievementId = 1, Title = "Locked", Description = "d", Criteria = "c", IsUnlocked = false },
+            new() { AchievementId = 2, Title = "Unlocked", Description = "d", Criteria = "c", IsUnlocked = true },
+        };
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(3))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.BuildRankShowcaseAsync(3);
+
+        // locked items get the lock icon, unlocked get the check icon
+        var locked = result.ShowcaseAchievements.Single(a => a.AchievementId == 1);
+        var unlocked = result.ShowcaseAchievements.Single(a => a.AchievementId == 2);
+        Assert.NotEqual(locked.Icon, unlocked.Icon);
+        Assert.True(unlocked.IsUnlocked);
+        Assert.False(locked.IsUnlocked);
+    }
+
+    [Fact]
+    public async Task BuildRankShowcase_FiveUnlocked_ReachesGymEnthusiastTier()
+    {
+        // leveling tiers: 0→Beginner, 1→Trainee, 2→Apprentice, 3→Gym Novice, 5→Gym Enthusiast
+        var showcase = Enumerable.Range(0, 5)
+            .Select(_ => new AchievementShowcaseItem { IsUnlocked = true })
+            .ToList();
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.BuildRankShowcaseAsync(1);
+
+        Assert.Equal(5, result.DisplayLevel);
+        Assert.Contains("Gym Enthusiast", result.LevelDisplayLine);
+    }
 }

--- a/Tests/ProgressionServiceTests.cs
+++ b/Tests/ProgressionServiceTests.cs
@@ -1,0 +1,277 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class ProgressionServiceTests
+{
+    private const double DefaultWeight = 50.0;
+    private const int DefaultTargetReps = 10;
+    private const int DefaultTemplateExerciseId = 1;
+
+    private readonly Mock<IWorkoutTemplateRepository> templateRepo = new();
+    private readonly Mock<INotificationRepository> notificationRepo = new();
+
+    private ProgressionService CreateService() => new(this.templateRepo.Object, this.notificationRepo.Object);
+
+    private static EvaluateWorkoutRequestDataTransferObject BuildRequest(
+        int clientId,
+        List<LoggedExerciseDataTransferObject> exercises) =>
+        new()
+        {
+            ClientId = clientId,
+            Exercises = exercises,
+        };
+
+    private static LoggedExerciseDataTransferObject BuildExercise(
+        int templateExerciseId,
+        string name,
+        params (int actualReps, float actualWeight)[] sets) =>
+        new()
+        {
+            ExerciseName = name,
+            ParentTemplateExerciseId = templateExerciseId,
+            Sets = sets.Select((s, i) => new LoggedSetDataTransferObject
+            {
+                ActualReps = s.actualReps,
+                ActualWeight = s.actualWeight,
+                TargetReps = DefaultTargetReps,
+                TargetWeight = (float)DefaultWeight,
+                SetIndex = i,
+                SetNumber = i + 1,
+            }).ToList(),
+        };
+
+    [Fact]
+    public async Task EvaluateWorkoutAsync_EmptyExercises_DoesNothing()
+    {
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>());
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.GetTemplateExerciseByIdAsync(It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateWorkoutAsync_ExerciseWithEmptySets_SkipsExercise()
+    {
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            new()
+            {
+                ParentTemplateExerciseId = DefaultTemplateExerciseId,
+                ExerciseName = "Bench Press",
+                Sets = new List<LoggedSetDataTransferObject>(),
+            },
+        });
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.GetTemplateExerciseByIdAsync(It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateWorkoutAsync_TemplateNotFound_SkipsExercise()
+    {
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Bench Press", (DefaultTargetReps, (float)DefaultWeight)),
+        });
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync((TemplateExercise?)null);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.UpdateTemplateExerciseWeightAsync(It.IsAny<int>(), It.IsAny<double>()),
+            Times.Never);
+        this.notificationRepo.Verify(
+            r => r.SaveNotificationAsync(It.IsAny<Notification>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateWorkoutAsync_PerfectPerformance_AppliesProgressiveOverload()
+    {
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Bench Press", (DefaultTargetReps, (float)DefaultWeight)),
+        });
+
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetReps = DefaultTargetReps,
+            TargetWeight = DefaultWeight,
+            MuscleGroup = MuscleGroup.CHEST,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+        this.templateRepo
+            .Setup(r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, DefaultWeight + 2.5))
+            .ReturnsAsync(true);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, DefaultWeight + 2.5),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateWorkoutAsync_LegsExercise_IncrementsBy5Kg()
+    {
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Squat", (DefaultTargetReps, (float)DefaultWeight)),
+        });
+        request.Exercises[0].TargetMuscles = "LEGS";
+
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetReps = DefaultTargetReps,
+            TargetWeight = DefaultWeight,
+            MuscleGroup = MuscleGroup.LEGS,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+        this.templateRepo
+            .Setup(r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, DefaultWeight + 5.0))
+            .ReturnsAsync(true);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, DefaultWeight + 5.0),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateWorkoutAsync_PlateauDetected_SavesNotification()
+    {
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Bench Press", (5, (float)DefaultWeight), (5, (float)DefaultWeight)),
+        });
+
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetReps = DefaultTargetReps,
+            TargetWeight = DefaultWeight,
+            MuscleGroup = MuscleGroup.CHEST,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.notificationRepo.Verify(
+            r => r.SaveNotificationAsync(It.Is<Notification>(n =>
+                n.Type == NotificationType.Plateau &&
+                n.RelatedId == DefaultTemplateExerciseId)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessDeloadAsync_TemplateNotFound_ReturnsFalse()
+    {
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync((TemplateExercise?)null);
+
+        var request = new ProcessDeloadRequestDataTransferObject
+        {
+            RelatedId = DefaultTemplateExerciseId,
+        };
+
+        var service = this.CreateService();
+        var result = await service.ProcessDeloadAsync(request);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ProcessDeloadAsync_ValidRequest_UpdatesWeightAndReturnsTrue()
+    {
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetWeight = 100,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+        this.templateRepo
+            .Setup(r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, 90.0))
+            .ReturnsAsync(true);
+
+        var request = new ProcessDeloadRequestDataTransferObject
+        {
+            RelatedId = DefaultTemplateExerciseId,
+        };
+
+        var service = this.CreateService();
+        var result = await service.ProcessDeloadAsync(request);
+
+        Assert.True(result);
+        this.templateRepo.Verify(
+            r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, 90.0),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(100, 90.0)]
+    [InlineData(50, 45.0)]
+    [InlineData(33, 29.5)]
+    public async Task ProcessDeloadAsync_DeloadWeight_IsRoundedCorrectly(double originalWeight, double expectedDeload)
+    {
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetWeight = originalWeight,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+        this.templateRepo
+            .Setup(r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, expectedDeload))
+            .ReturnsAsync(true);
+
+        var request = new ProcessDeloadRequestDataTransferObject
+        {
+            RelatedId = DefaultTemplateExerciseId,
+        };
+
+        var service = this.CreateService();
+        await service.ProcessDeloadAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, expectedDeload),
+            Times.Once);
+    }
+}

--- a/Tests/ProgressionServiceTests.cs
+++ b/Tests/ProgressionServiceTests.cs
@@ -247,6 +247,7 @@ public sealed class ProgressionServiceTests
     [InlineData(100, 90.0)]
     [InlineData(50, 45.0)]
     [InlineData(33, 29.5)]
+    [InlineData(0, 0.0)]
     public async Task ProcessDeloadAsync_DeloadWeight_IsRoundedCorrectly(double originalWeight, double expectedDeload)
     {
         var template = new TemplateExercise
@@ -273,5 +274,129 @@ public sealed class ProgressionServiceTests
         this.templateRepo.Verify(
             r => r.UpdateTemplateExerciseWeightAsync(DefaultTemplateExerciseId, expectedDeload),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task AveragePerformance_NeitherPlateauNorOverload_DoesNotModifyAnything()
+    {
+        // 9 out of 10 reps → ratio 0.9, which is exactly at the plateau threshold
+        // but NOT consecutive failures, and below 1.0 overload threshold.
+        // neither path should trigger.
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Bench Press", (9, (float)DefaultWeight)),
+        });
+
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetReps = DefaultTargetReps,
+            TargetWeight = DefaultWeight,
+            MuscleGroup = MuscleGroup.CHEST,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.UpdateTemplateExerciseWeightAsync(It.IsAny<int>(), It.IsAny<double>()),
+            Times.Never);
+        this.notificationRepo.Verify(
+            r => r.SaveNotificationAsync(It.IsAny<Notification>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Plateau_should_include_exercise_name_in_notification_message()
+    {
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Overhead Press", (3, 40f), (3, 40f)),
+        });
+
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetReps = DefaultTargetReps,
+            TargetWeight = DefaultWeight,
+            MuscleGroup = MuscleGroup.SHOULDERS,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.notificationRepo.Verify(r => r.SaveNotificationAsync(
+            It.Is<Notification>(n => n.Message.Contains("Overhead Press"))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateWorkout_ZeroTargetReps_TreatsRatioAsZero()
+    {
+        // TargetReps = 0 on the template → ratio computation divides by 0
+        // should produce 0.0 ratio → below overload threshold, single set so no plateau
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Tricep Dip", (5, 20f)),
+        });
+
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetReps = 0,
+            TargetWeight = 20,
+            MuscleGroup = MuscleGroup.ARMS,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.templateRepo.Verify(
+            r => r.UpdateTemplateExerciseWeightAsync(It.IsAny<int>(), It.IsAny<double>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PlateauNeedsConsecutiveFailures_NotJustAnyTwoBelow()
+    {
+        // pattern: fail, pass, fail — should NOT trigger plateau (failures aren't consecutive)
+        var request = BuildRequest(1, new List<LoggedExerciseDataTransferObject>
+        {
+            BuildExercise(DefaultTemplateExerciseId, "Bench Press",
+                (3, (float)DefaultWeight),   // fail: 3/10 = 0.3
+                (10, (float)DefaultWeight),  // pass: 10/10 = 1.0
+                (3, (float)DefaultWeight)),  // fail: 3/10 = 0.3
+        });
+
+        var template = new TemplateExercise
+        {
+            TemplateExerciseId = DefaultTemplateExerciseId,
+            TargetReps = DefaultTargetReps,
+            TargetWeight = DefaultWeight,
+            MuscleGroup = MuscleGroup.CHEST,
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetTemplateExerciseByIdAsync(DefaultTemplateExerciseId))
+            .ReturnsAsync(template);
+
+        var service = this.CreateService();
+        await service.EvaluateWorkoutAsync(request);
+
+        this.notificationRepo.Verify(
+            r => r.SaveNotificationAsync(It.IsAny<Notification>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
Ported the EvaluationEngine and ProgressionService test files from the VibeCoders fork into our test suite. Rewrote everything to use Moq instead of NSubstitute and adapted to our async service API with DTOs.

EvaluationEngineServiceTests covers the rank showcase logic, singular/plural achievement display, and the evaluate flow. ProgressionServiceTests covers progressive overload, plateau detection, deload rounding, and the usual edge cases (empty sets, missing templates, etc).

All 17 tests passing locally.

Closes #346
Closes #347