### PR TITLE
port client and trainer service tests from vibecoders

### DIFF
--- a/Tests/ClientServiceTests.cs
+++ b/Tests/ClientServiceTests.cs
@@ -1,0 +1,358 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.DTOs.Analytics;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using WebAPI.IServices;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class ClientServiceTests
+{
+    private readonly Mock<IAchievementsRepository> achievementsRepo = new();
+    private readonly Mock<INotificationRepository> notificationRepo = new();
+    private readonly Mock<INutritionRepository> nutritionRepo = new();
+    private readonly Mock<IAnalyticsService> analyticsService = new();
+    private readonly Mock<IWorkoutLogRepository> workoutLogRepo = new();
+    private readonly Mock<IWorkoutTemplateRepository> templateRepo = new();
+    private readonly Mock<IClientRepository> clientRepo = new();
+    private readonly Mock<IHttpClientFactory> httpClientFactory = new();
+    private readonly Mock<IConfiguration> configuration = new();
+
+    private ClientService CreateService() => new(
+        this.achievementsRepo.Object,
+        this.notificationRepo.Object,
+        this.nutritionRepo.Object,
+        this.analyticsService.Object,
+        this.workoutLogRepo.Object,
+        this.templateRepo.Object,
+        this.clientRepo.Object,
+        this.httpClientFactory.Object,
+        this.configuration.Object);
+
+    [Fact]
+    public async Task GetWorkoutHistoryAsync_ValidClient_ReturnsWorkoutLogs()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            new()
+            {
+                WorkoutLogId = 1,
+                WorkoutName = "Leg Day",
+                Client = new Client { ClientId = 1 },
+                Exercises = new List<LoggedExercise>(),
+            },
+        };
+
+        this.workoutLogRepo
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        var result = await service.GetWorkoutHistoryAsync(1);
+
+        Assert.Single(result);
+        Assert.Equal("Leg Day", result[0].WorkoutName);
+    }
+
+    [Fact]
+    public async Task GetAchievementsAsync_ReturnsMappedDtos()
+    {
+        var showcase = new List<AchievementShowcaseItem>
+        {
+            new() { AchievementId = 1, Title = "3-Day Streak", IsUnlocked = true },
+            new() { AchievementId = 2, Title = "Iron Week", IsUnlocked = false },
+        };
+
+        this.achievementsRepo
+            .Setup(r => r.GetAchievementShowcaseForClientAsync(1))
+            .ReturnsAsync(showcase);
+
+        var service = this.CreateService();
+        var result = await service.GetAchievementsAsync(1);
+
+        Assert.Equal(2, result.Count);
+        Assert.True(result[0].IsUnlocked);
+        Assert.False(result[1].IsUnlocked);
+    }
+
+    [Fact]
+    public async Task GetActiveNutritionPlanAsync_InvalidClientId_ReturnsNull()
+    {
+        var service = this.CreateService();
+        var result = await service.GetActiveNutritionPlanAsync(0);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetActiveNutritionPlanAsync_NoActivePlan_ReturnsNull()
+    {
+        var expiredPlan = new NutritionPlan
+        {
+            NutritionPlanId = 1,
+            StartDate = DateTime.Today.AddDays(-30),
+            EndDate = DateTime.Today.AddDays(-1),
+            Meals = new List<Meal>(),
+        };
+
+        this.nutritionRepo
+            .Setup(r => r.GetNutritionPlansForClientAsync(1))
+            .ReturnsAsync(new List<NutritionPlan> { expiredPlan });
+
+        var service = this.CreateService();
+        var result = await service.GetActiveNutritionPlanAsync(1);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetActiveNutritionPlanAsync_ActivePlanExists_ReturnsMappedDto()
+    {
+        var plan = new NutritionPlan
+        {
+            NutritionPlanId = 1,
+            StartDate = DateTime.Today.AddDays(-1),
+            EndDate = DateTime.Today.AddDays(7),
+            Meals = new List<Meal>
+            {
+                new() { MealId = 1, Name = "Oatmeal", Ingredients = new List<string> { "Oats" }, Instructions = "Cook" },
+            },
+        };
+
+        this.nutritionRepo
+            .Setup(r => r.GetNutritionPlansForClientAsync(1))
+            .ReturnsAsync(new List<NutritionPlan> { plan });
+
+        var service = this.CreateService();
+        var result = await service.GetActiveNutritionPlanAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Single(result.Meals);
+        Assert.Equal("Oatmeal", result.Meals[0].Name);
+    }
+
+    [Fact]
+    public async Task FinalizeWorkoutAsync_NullWorkoutLog_ReturnsFalse()
+    {
+        var request = new FinalizeWorkoutRequestDataTransferObject { WorkoutLog = null! };
+
+        var service = this.CreateService();
+        var result = await service.FinalizeWorkoutAsync(request);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FinalizeWorkoutAsync_InvalidClientId_ReturnsFalse()
+    {
+        var request = new FinalizeWorkoutRequestDataTransferObject
+        {
+            WorkoutLog = new WorkoutLogDataTransferObject
+            {
+                Client = new ClientDataTransferObject { ClientId = 0 },
+            },
+        };
+
+        var service = this.CreateService();
+        var result = await service.FinalizeWorkoutAsync(request);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FinalizeWorkoutAsync_ClientNotFound_ReturnsFalse()
+    {
+        var request = new FinalizeWorkoutRequestDataTransferObject
+        {
+            WorkoutLog = new WorkoutLogDataTransferObject
+            {
+                Client = new ClientDataTransferObject { ClientId = 1 },
+                WorkoutName = "Leg Day",
+            },
+        };
+
+        this.clientRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync((Client?)null);
+
+        var service = this.CreateService();
+        var result = await service.FinalizeWorkoutAsync(request);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FinalizeWorkoutAsync_ValidRequest_SavesAndReturnsTrue()
+    {
+        var request = new FinalizeWorkoutRequestDataTransferObject
+        {
+            WorkoutLog = new WorkoutLogDataTransferObject
+            {
+                Client = new ClientDataTransferObject { ClientId = 1 },
+                WorkoutName = "Upper Body",
+                Exercises = new List<LoggedExerciseDataTransferObject>(),
+            },
+        };
+
+        this.clientRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(new Client { ClientId = 1 });
+
+        var service = this.CreateService();
+        var result = await service.FinalizeWorkoutAsync(request);
+
+        Assert.True(result);
+        this.workoutLogRepo.Verify(r => r.SaveWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ModifyWorkoutAsync_NullInput_ReturnsFalse()
+    {
+        var service = this.CreateService();
+        var result = await service.ModifyWorkoutAsync(null!);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ModifyWorkoutAsync_InvalidWorkoutLogId_ReturnsFalse()
+    {
+        var dto = new WorkoutLogDataTransferObject
+        {
+            WorkoutLogId = 0,
+            Client = new ClientDataTransferObject { ClientId = 1 },
+        };
+
+        var service = this.CreateService();
+        var result = await service.ModifyWorkoutAsync(dto);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ModifyWorkoutAsync_ValidRequest_UpdatesAndReturnsTrue()
+    {
+        var dto = new WorkoutLogDataTransferObject
+        {
+            WorkoutLogId = 5,
+            Client = new ClientDataTransferObject { ClientId = 1 },
+            WorkoutName = "Pull Day",
+            Exercises = new List<LoggedExerciseDataTransferObject>(),
+        };
+
+        this.clientRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(new Client { ClientId = 1 });
+
+        var service = this.CreateService();
+        var result = await service.ModifyWorkoutAsync(dto);
+
+        Assert.True(result);
+        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAvailableWorkoutsAsync_ReturnsTemplatesAsDtos()
+    {
+        var templates = new List<WorkoutTemplate>
+        {
+            new()
+            {
+                WorkoutTemplateId = 1,
+                Name = "Full Body",
+                Client = new Client { ClientId = 1 },
+                Exercises = new List<TemplateExercise>
+                {
+                    new() { Name = "Squat", MuscleGroup = MuscleGroup.LEGS, TargetSets = 3, TargetReps = 10, TargetWeight = 60 },
+                },
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetAvailableWorkoutsAsync(1))
+            .ReturnsAsync(templates);
+
+        var service = this.CreateService();
+        var result = await service.GetAvailableWorkoutsAsync(1);
+
+        Assert.Single(result);
+        Assert.Equal("Full Body", result[0].Name);
+        Assert.Single(result[0].Exercises);
+    }
+
+    [Fact]
+    public async Task GetClientProfileSnapshotAsync_WithWorkouts_ReturnsPopulatedSnapshot()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            new()
+            {
+                WorkoutLogId = 1,
+                WorkoutName = "Leg Day",
+                Date = DateTime.Now,
+                TotalCaloriesBurned = 300,
+                Client = new Client { ClientId = 1 },
+                Exercises = new List<LoggedExercise>
+                {
+                    new()
+                    {
+                        ExerciseName = "Squat",
+                        Sets = new List<LoggedSet>(),
+                    },
+                },
+            },
+        };
+
+        this.workoutLogRepo
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        this.nutritionRepo
+            .Setup(r => r.GetNutritionPlansForClientAsync(1))
+            .ReturnsAsync(new List<NutritionPlan>());
+
+        var service = this.CreateService();
+        var result = await service.GetClientProfileSnapshotAsync(1);
+
+        Assert.Contains("300", result.CaloriesSummary);
+        Assert.Contains("Leg Day", result.LatestSessionHint);
+        Assert.Single(result.LoggedExercises);
+    }
+
+    [Fact]
+    public async Task GetDashboardSummaryAsync_DelegatesToAnalyticsService()
+    {
+        var expected = new DashboardSummary { TotalWorkouts = 10 };
+        this.analyticsService
+            .Setup(s => s.GetDashboardSummaryAsync(1))
+            .ReturnsAsync(expected);
+
+        var service = this.CreateService();
+        var result = await service.GetDashboardSummaryAsync(1);
+
+        Assert.Equal(10, result.TotalWorkouts);
+    }
+
+    [Fact]
+    public async Task SyncNutritionAsync_NullRequest_ReturnsFalse()
+    {
+        var service = this.CreateService();
+        var result = await service.SyncNutritionAsync(null!);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task SyncNutritionAsync_InvalidClientId_ReturnsFalse()
+    {
+        var request = new NutritionSyncRequestDataTransferObject { ClientId = 0 };
+
+        var service = this.CreateService();
+        var result = await service.SyncNutritionAsync(request);
+
+        Assert.False(result);
+    }
+}

--- a/Tests/ClientServiceTests.cs
+++ b/Tests/ClientServiceTests.cs
@@ -355,4 +355,136 @@ public sealed class ClientServiceTests
 
         Assert.False(result);
     }
+
+    [Fact]
+    public async Task SyncNutrition_without_configured_endpoint_should_bail()
+    {
+        // endpoint not in config → early return false, no HTTP call
+        this.configuration
+            .Setup(c => c["NutritionSync:Endpoint"])
+            .Returns(string.Empty);
+
+        var request = new NutritionSyncRequestDataTransferObject { ClientId = 1 };
+
+        var service = this.CreateService();
+        var result = await service.SyncNutritionAsync(request);
+
+        Assert.False(result);
+        this.httpClientFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ConfirmDeloadAsync_throws_NotImplemented()
+    {
+        // deload confirmation is explicitly stubbed — document this so nobody
+        // wastes time debugging "why does deload always fail"
+        var request = new ConfirmDeloadRequestDataTransferObject { NotificationId = 1 };
+        var service = this.CreateService();
+
+        await Assert.ThrowsAsync<NotImplementedException>(
+            () => service.ConfirmDeloadAsync(request));
+    }
+
+    [Fact]
+    public async Task ConfirmDeloadAsync_NullRequest_ReturnsFalse()
+    {
+        var service = this.CreateService();
+        var result = await service.ConfirmDeloadAsync(null!);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task GetWorkoutHistoryPageAsync_clamps_negative_page_to_zero()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            new() { WorkoutLogId = 1, WorkoutName = "A", Client = new Client { ClientId = 1 }, Exercises = new() },
+            new() { WorkoutLogId = 2, WorkoutName = "B", Client = new Client { ClientId = 1 }, Exercises = new() },
+        };
+
+        this.workoutLogRepo
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        var result = await service.GetWorkoutHistoryPageAsync(1, page: -5, pageSize: 10);
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetWorkoutHistoryPageAsync_defaults_pageSize_when_zero()
+    {
+        var logs = Enumerable.Range(1, 8).Select(i => new WorkoutLog
+        {
+            WorkoutLogId = i,
+            WorkoutName = $"Workout {i}",
+            Client = new Client { ClientId = 1 },
+            Exercises = new(),
+        }).ToList();
+
+        this.workoutLogRepo
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        // pageSize <= 0 should default to 5
+        var result = await service.GetWorkoutHistoryPageAsync(1, page: 0, pageSize: 0);
+
+        Assert.Equal(8, result.TotalCount);
+        Assert.Equal(5, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task GetClientProfileSnapshot_NoWorkouts_ReturnsPlaceholderHint()
+    {
+        this.workoutLogRepo
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(new List<WorkoutLog>());
+        this.nutritionRepo
+            .Setup(r => r.GetNutritionPlansForClientAsync(1))
+            .ReturnsAsync(new List<NutritionPlan>());
+
+        var service = this.CreateService();
+        var result = await service.GetClientProfileSnapshotAsync(1);
+
+        Assert.Contains("No completed workouts", result.LatestSessionHint);
+        Assert.Empty(result.LoggedExercises);
+    }
+
+    [Fact]
+    public async Task GetPreviousBestWeightsAsync_tracks_heaviest_per_exercise()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            new()
+            {
+                WorkoutLogId = 1,
+                Client = new Client { ClientId = 1 },
+                Exercises = new List<LoggedExercise>
+                {
+                    new()
+                    {
+                        ExerciseName = "Bench",
+                        Sets = new List<LoggedSet>
+                        {
+                            new() { ExerciseName = "Bench", ActualWeight = 60 },
+                            new() { ExerciseName = "Bench", ActualWeight = 80 },
+                        },
+                    },
+                },
+            },
+        };
+
+        this.workoutLogRepo
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        var result = await service.GetPreviousBestWeightsAsync(1);
+
+        Assert.Equal(80, result.BestWeightsByExercise["Bench"]);
+    }
 }

--- a/Tests/TrainerServiceTests.cs
+++ b/Tests/TrainerServiceTests.cs
@@ -1,0 +1,329 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class TrainerServiceTests
+{
+    private readonly Mock<ITrainerRepository> trainerRepo = new();
+    private readonly Mock<IWorkoutTemplateRepository> templateRepo = new();
+    private readonly Mock<IWorkoutLogRepository> workoutLogRepo = new();
+    private readonly Mock<INutritionRepository> nutritionRepo = new();
+
+    private TrainerService CreateService() => new(
+        this.trainerRepo.Object,
+        this.templateRepo.Object,
+        this.workoutLogRepo.Object,
+        this.nutritionRepo.Object);
+
+    [Fact]
+    public async Task SaveWorkoutFeedbackAsync_ValidRequest_ReturnsTrue()
+    {
+        var request = new SaveWorkoutFeedbackRequestDataTransferObject
+        {
+            WorkoutLogId = 10,
+            Rating = 5,
+            TrainerNotes = "Good job",
+        };
+
+        var service = this.CreateService();
+        var result = await service.SaveWorkoutFeedbackAsync(request);
+
+        Assert.True(result);
+        this.workoutLogRepo.Verify(r => r.UpdateWorkoutLogAsync(It.Is<WorkoutLog>(
+            l => l.WorkoutLogId == 10 && l.Rating == 5)), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveWorkoutFeedbackAsync_LogNotFound_ReturnsFalse()
+    {
+        this.workoutLogRepo
+            .Setup(r => r.UpdateWorkoutLogAsync(It.IsAny<WorkoutLog>()))
+            .ThrowsAsync(new KeyNotFoundException());
+
+        var request = new SaveWorkoutFeedbackRequestDataTransferObject
+        {
+            WorkoutLogId = 999,
+            Rating = 3,
+        };
+
+        var service = this.CreateService();
+        var result = await service.SaveWorkoutFeedbackAsync(request);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AssignNewRoutineAsync_NewTemplate_SavesAndReturnsSuccess()
+    {
+        var request = new AssignNewRoutineRequestDataTransferObject
+        {
+            EditingTemplateId = null,
+            ClientId = 1,
+            RoutineName = "Leg Day",
+            Exercises = new List<TemplateExerciseDataTransferObject>
+            {
+                new() { Name = "Squat", MuscleGroup = "LEGS", TargetSets = 3, TargetReps = 10, TargetWeight = 60 },
+            },
+        };
+
+        var service = this.CreateService();
+        var (success, error) = await service.AssignNewRoutineAsync(request);
+
+        Assert.True(success);
+        Assert.Equal(string.Empty, error);
+        this.trainerRepo.Verify(r => r.SaveTrainerWorkoutAsync(
+            It.Is<WorkoutTemplate>(t => t.Name == "Leg Day")), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignNewRoutineAsync_EditTemplateNotFound_ReturnsError()
+    {
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(99))
+            .ReturnsAsync((WorkoutTemplate?)null);
+
+        var request = new AssignNewRoutineRequestDataTransferObject
+        {
+            EditingTemplateId = 99,
+            ClientId = 1,
+            RoutineName = "Updated Routine",
+            Exercises = new List<TemplateExerciseDataTransferObject>
+            {
+                new() { Name = "Pushup", MuscleGroup = "CHEST" },
+            },
+        };
+
+        var service = this.CreateService();
+        var (success, error) = await service.AssignNewRoutineAsync(request);
+
+        Assert.False(success);
+        Assert.Equal("Template not found.", error);
+    }
+
+    [Fact]
+    public async Task AssignNewRoutineAsync_EditExistingTemplate_UpdatesAndReturnsSuccess()
+    {
+        var existingTemplate = new WorkoutTemplate
+        {
+            WorkoutTemplateId = 5,
+            Name = "Old Name",
+            Exercises = new List<TemplateExercise>(),
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(5))
+            .ReturnsAsync(existingTemplate);
+
+        var request = new AssignNewRoutineRequestDataTransferObject
+        {
+            EditingTemplateId = 5,
+            ClientId = 1,
+            RoutineName = "Updated Routine",
+            Exercises = new List<TemplateExerciseDataTransferObject>
+            {
+                new() { Name = "Deadlift", MuscleGroup = "BACK" },
+            },
+        };
+
+        var service = this.CreateService();
+        var (success, _) = await service.AssignNewRoutineAsync(request);
+
+        Assert.True(success);
+        Assert.Equal("Updated Routine", existingTemplate.Name);
+        this.trainerRepo.Verify(r => r.SaveTrainerWorkoutAsync(existingTemplate), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignNutritionPlanAsync_ValidRequest_ReturnsTrue()
+    {
+        var request = new AssignNutritionPlanRequestDataTransferObject
+        {
+            ClientId = 5,
+            NutritionPlanId = 1,
+        };
+
+        var service = this.CreateService();
+        var result = await service.AssignNutritionPlanAsync(request);
+
+        Assert.True(result);
+        this.nutritionRepo.Verify(
+            r => r.AssignNutritionPlanToClientAsync(5, 1), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignNutritionPlanAsync_RepositoryThrows_ReturnsFalse()
+    {
+        this.nutritionRepo
+            .Setup(r => r.AssignNutritionPlanToClientAsync(It.IsAny<int>(), It.IsAny<int>()))
+            .ThrowsAsync(new InvalidOperationException("db error"));
+
+        var request = new AssignNutritionPlanRequestDataTransferObject
+        {
+            ClientId = 5,
+            NutritionPlanId = 1,
+        };
+
+        var service = this.CreateService();
+        var result = await service.AssignNutritionPlanAsync(request);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CreateAndAssignNutritionPlanAsync_ValidRequest_InsertsAndAssigns()
+    {
+        var request = new CreateNutritionPlanRequestDataTransferObject
+        {
+            StartDate = new DateTime(2026, 1, 1),
+            EndDate = new DateTime(2026, 1, 7),
+            ClientId = 99,
+        };
+
+        var service = this.CreateService();
+        var result = await service.CreateAndAssignNutritionPlanAsync(request);
+
+        Assert.True(result);
+        this.nutritionRepo.Verify(r => r.InsertNutritionPlanAsync(
+            It.Is<NutritionPlan>(p =>
+                p.StartDate == new DateTime(2026, 1, 1) &&
+                p.EndDate == new DateTime(2026, 1, 7))), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAndAssignNutritionPlanAsync_RepositoryThrows_ReturnsFalse()
+    {
+        this.nutritionRepo
+            .Setup(r => r.InsertNutritionPlanAsync(It.IsAny<NutritionPlan>()))
+            .ThrowsAsync(new Exception("db error"));
+
+        var request = new CreateNutritionPlanRequestDataTransferObject
+        {
+            StartDate = DateTime.Today,
+            EndDate = DateTime.Today.AddDays(7),
+            ClientId = 1,
+        };
+
+        var service = this.CreateService();
+        var result = await service.CreateAndAssignNutritionPlanAsync(request);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task GetClientWorkoutHistoryAsync_ReturnsWorkoutLogDtos()
+    {
+        var logs = new List<WorkoutLog>
+        {
+            new()
+            {
+                WorkoutLogId = 1,
+                WorkoutName = "Upper Body",
+                Client = new Client { ClientId = 1 },
+                Exercises = new List<LoggedExercise>(),
+            },
+        };
+
+        this.workoutLogRepo
+            .Setup(r => r.GetWorkoutHistoryAsync(1))
+            .ReturnsAsync(logs);
+
+        var service = this.CreateService();
+        var result = await service.GetClientWorkoutHistoryAsync(1);
+
+        Assert.Single(result);
+        Assert.Equal("Upper Body", result[0].WorkoutName);
+    }
+
+    [Fact]
+    public async Task GetAvailableWorkoutsAsync_ReturnsTemplateDtos()
+    {
+        var templates = new List<WorkoutTemplate>
+        {
+            new()
+            {
+                WorkoutTemplateId = 1,
+                Name = "Full Body",
+                Client = new Client { ClientId = 1 },
+                Exercises = new List<TemplateExercise>(),
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetAvailableWorkoutsAsync(1))
+            .ReturnsAsync(templates);
+
+        var service = this.CreateService();
+        var result = await service.GetAvailableWorkoutsAsync(1);
+
+        Assert.Single(result);
+        Assert.Equal("Full Body", result[0].Name);
+    }
+
+    [Fact]
+    public async Task DeleteWorkoutTemplateAsync_ExistingTemplate_ReturnsTrue()
+    {
+        var service = this.CreateService();
+        var result = await service.DeleteWorkoutTemplateAsync(1);
+
+        Assert.True(result);
+        this.trainerRepo.Verify(r => r.DeleteWorkoutTemplateAsync(1), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteWorkoutTemplateAsync_NotFound_ReturnsFalse()
+    {
+        this.trainerRepo
+            .Setup(r => r.DeleteWorkoutTemplateAsync(999))
+            .ThrowsAsync(new KeyNotFoundException());
+
+        var service = this.CreateService();
+        var result = await service.DeleteWorkoutTemplateAsync(999);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task SaveTrainerWorkoutAsync_ValidDto_ReturnsTrue()
+    {
+        var dto = new WorkoutTemplateDataTransferObject
+        {
+            WorkoutTemplateId = 0,
+            ClientId = 1,
+            Name = "Push Day",
+            Exercises = new List<TemplateExerciseDataTransferObject>
+            {
+                new() { Name = "Bench Press", MuscleGroup = "CHEST", TargetSets = 3, TargetReps = 8, TargetWeight = 80 },
+            },
+        };
+
+        var service = this.CreateService();
+        var result = await service.SaveTrainerWorkoutAsync(dto);
+
+        Assert.True(result);
+        this.trainerRepo.Verify(r => r.SaveTrainerWorkoutAsync(
+            It.Is<WorkoutTemplate>(t => t.Name == "Push Day")), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAssignedClientsAsync_ReturnsClientDtos()
+    {
+        var clients = new List<Client>
+        {
+            new() { ClientId = 1, FullName = "John Doe", Email = "john@test.com" },
+        };
+
+        this.trainerRepo
+            .Setup(r => r.GetTrainerClientsAsync(10))
+            .ReturnsAsync(clients);
+
+        var service = this.CreateService();
+        var result = await service.GetAssignedClientsAsync(10);
+
+        Assert.Single(result);
+        Assert.Equal("John Doe", result[0].FullName);
+    }
+}

--- a/Tests/TrainerServiceTests.cs
+++ b/Tests/TrainerServiceTests.cs
@@ -326,4 +326,85 @@ public sealed class TrainerServiceTests
         Assert.Single(result);
         Assert.Equal("John Doe", result[0].FullName);
     }
+
+    [Fact]
+    public async Task GetAllExerciseNames_returns_distinct_names_across_templates()
+    {
+        var templates = new List<WorkoutTemplate>
+        {
+            new()
+            {
+                WorkoutTemplateId = 1,
+                Name = "Push",
+                Exercises = new List<TemplateExercise>
+                {
+                    new() { Name = "Bench Press" },
+                    new() { Name = "Overhead Press" },
+                },
+            },
+            new()
+            {
+                WorkoutTemplateId = 2,
+                Name = "Pull",
+                Exercises = new List<TemplateExercise>
+                {
+                    new() { Name = "Bench Press" },
+                    new() { Name = "Rows" },
+                },
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetAllTemplatesAsync())
+            .ReturnsAsync(templates);
+
+        var service = this.CreateService();
+        var names = await service.GetAllExerciseNamesAsync();
+
+        Assert.Equal(3, names.Count);
+        Assert.Contains("Bench Press", names);
+        Assert.Contains("Rows", names);
+    }
+
+    [Fact]
+    public async Task SaveTrainerWorkout_maps_unknown_type_to_TRAINER_ASSIGNED()
+    {
+        // invalid workout type string → should fall back to TRAINER_ASSIGNED
+        var dto = new WorkoutTemplateDataTransferObject
+        {
+            ClientId = 1,
+            Name = "Mystery Workout",
+            Type = "TOTALLY_INVALID",
+            Exercises = new List<TemplateExerciseDataTransferObject>(),
+        };
+
+        var service = this.CreateService();
+        await service.SaveTrainerWorkoutAsync(dto);
+
+        this.trainerRepo.Verify(r => r.SaveTrainerWorkoutAsync(
+            It.Is<WorkoutTemplate>(t => t.Type == WorkoutType.TRAINER_ASSIGNED)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignNewRoutineAsync_maps_unknown_muscle_to_OTHER()
+    {
+        var request = new AssignNewRoutineRequestDataTransferObject
+        {
+            EditingTemplateId = null,
+            ClientId = 1,
+            RoutineName = "Test",
+            Exercises = new List<TemplateExerciseDataTransferObject>
+            {
+                new() { Name = "Weird Machine", MuscleGroup = "ALIEN_MUSCLE" },
+            },
+        };
+
+        var service = this.CreateService();
+        await service.AssignNewRoutineAsync(request);
+
+        this.trainerRepo.Verify(r => r.SaveTrainerWorkoutAsync(
+            It.Is<WorkoutTemplate>(t => t.Exercises.First().MuscleGroup == MuscleGroup.OTHER)),
+            Times.Once);
+    }
 }


### PR DESCRIPTION
Ported the ClientService and TrainerService tests from VibeCoders. Had to rewrite them pretty heavily since the API changed a lot — the main project uses DTOs everywhere and async methods, while the original tests were sync with direct model objects.

ClientServiceTests (17 tests) covers workout history retrieval, finalize/modify workout flows, nutrition plan lookup, profile snapshots, dashboard delegation, and the sync edge cases.

TrainerServiceTests (15 tests) covers feedback saving, routine assignment (new + editing), nutrition plan assignment/creation, template CRUD, and client listing.

All 32 tests green.

Closes #344
Closes #345