### PR TITLE
port calendar and navigation service tests from vibecoders

### DIFF
--- a/Tests/CalendarExportServiceTests.cs
+++ b/Tests/CalendarExportServiceTests.cs
@@ -64,6 +64,21 @@ public sealed class CalendarExportServiceTests
     }
 
     [Fact]
+    public async Task GenerateCalendar_null_SelectedDays_throws_ArgumentException()
+    {
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 4,
+            SelectedDays = null!,
+        };
+
+        var service = this.CreateService();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => service.GenerateCalendarAsync(request));
+    }
+
+    [Fact]
     public async Task GenerateCalendarAsync_ValidTemplate_GeneratesCorrectEventCount()
     {
         var template = new WorkoutTemplate
@@ -170,6 +185,87 @@ public sealed class CalendarExportServiceTests
 
         Assert.Contains("BEGIN:VCALENDAR", result.IcsContent);
         Assert.Contains("END:VCALENDAR", result.IcsContent);
+    }
+
+    [Fact]
+    public async Task GenerateCalendar_exercises_with_special_chars_are_ICS_escaped()
+    {
+        var template = new WorkoutTemplate
+        {
+            WorkoutTemplateId = 1,
+            Name = "Back, Bis & Abs",
+            Exercises = new List<TemplateExercise>
+            {
+                new() { Name = "Pull-up; wide grip", TargetSets = 3, TargetReps = 8, TargetWeight = 0 },
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(template);
+
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 1,
+            SelectedDays = new List<DayOfWeek> { DayOfWeek.Tuesday },
+            StartDate = new DateTime(2026, 5, 5),
+        };
+
+        var service = this.CreateService();
+        var result = await service.GenerateCalendarAsync(request);
+
+        // ICS spec requires commas and semicolons to be escaped
+        Assert.Contains("Back\\, Bis & Abs", result.IcsContent);
+    }
+
+    [Fact]
+    public async Task GenerateCalendar_with_no_StartDate_defaults_to_today()
+    {
+        var template = new WorkoutTemplate
+        {
+            WorkoutTemplateId = 1,
+            Name = "Quick",
+            Exercises = new List<TemplateExercise>(),
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(template);
+
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 1,
+            SelectedDays = new List<DayOfWeek> { DateTime.Now.DayOfWeek },
+            StartDate = null,
+        };
+
+        var service = this.CreateService();
+        var result = await service.GenerateCalendarAsync(request);
+
+        // at least one event is generated for today's day-of-week
+        int eventCount = CountOccurrences(result.IcsContent, "BEGIN:VEVENT");
+        Assert.True(eventCount >= 1);
+    }
+
+    [Fact]
+    public async Task SaveCalendar_null_workout_name_produces_safe_filename()
+    {
+        var request = new SaveCalendarRequestDataTransferObject
+        {
+            IcsContent = "BEGIN:VCALENDAR\nEND:VCALENDAR",
+            WorkoutName = null,
+        };
+
+        var service = this.CreateService();
+        var result = await service.SaveCalendarAsync(request);
+
+        // null name should fall back to "workout" and still succeed
+        if (result.IsSuccess)
+        {
+            Assert.Contains("workout", result.FilePath!);
+        }
     }
 
     private static int CountOccurrences(string text, string pattern)

--- a/Tests/CalendarExportServiceTests.cs
+++ b/Tests/CalendarExportServiceTests.cs
@@ -1,0 +1,187 @@
+using ClassLibrary.DTOs;
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class CalendarExportServiceTests
+{
+    private readonly Mock<IWorkoutTemplateRepository> templateRepo = new();
+
+    private CalendarExportService CreateService() => new(this.templateRepo.Object);
+
+    [Fact]
+    public async Task GenerateCalendarAsync_TemplateNotFound_ThrowsArgumentNullException()
+    {
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync((WorkoutTemplate?)null);
+
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 4,
+            SelectedDays = new List<DayOfWeek> { DayOfWeek.Monday },
+        };
+
+        var service = this.CreateService();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.GenerateCalendarAsync(request));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(53)]
+    public async Task GenerateCalendarAsync_InvalidDurationWeeks_ThrowsArgumentOutOfRange(int invalidWeeks)
+    {
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = invalidWeeks,
+            SelectedDays = new List<DayOfWeek> { DayOfWeek.Monday },
+        };
+
+        var service = this.CreateService();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => service.GenerateCalendarAsync(request));
+    }
+
+    [Fact]
+    public async Task GenerateCalendarAsync_NoDaysSelected_ThrowsArgumentException()
+    {
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 4,
+            SelectedDays = new List<DayOfWeek>(),
+        };
+
+        var service = this.CreateService();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => service.GenerateCalendarAsync(request));
+    }
+
+    [Fact]
+    public async Task GenerateCalendarAsync_ValidTemplate_GeneratesCorrectEventCount()
+    {
+        var template = new WorkoutTemplate
+        {
+            WorkoutTemplateId = 1,
+            Name = "Full Body",
+            Exercises = new List<TemplateExercise>
+            {
+                new() { Name = "Squat", TargetSets = 3, TargetReps = 10, TargetWeight = 60 },
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(template);
+
+        var startDate = new DateTime(2026, 5, 5); // Monday
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 3,
+            SelectedDays = new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday },
+            StartDate = startDate,
+        };
+
+        var service = this.CreateService();
+        var result = await service.GenerateCalendarAsync(request);
+
+        int eventCount = CountOccurrences(result.IcsContent, "BEGIN:VEVENT");
+        Assert.Equal(9, eventCount);
+    }
+
+    [Fact]
+    public async Task GenerateCalendarAsync_IncludesExerciseDescription()
+    {
+        var template = new WorkoutTemplate
+        {
+            WorkoutTemplateId = 1,
+            Name = "Strength",
+            Exercises = new List<TemplateExercise>
+            {
+                new() { Name = "Deadlift", TargetSets = 5, TargetReps = 5, TargetWeight = 100 },
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(template);
+
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 1,
+            SelectedDays = new List<DayOfWeek> { DayOfWeek.Monday },
+            StartDate = new DateTime(2026, 5, 5),
+        };
+
+        var service = this.CreateService();
+        var result = await service.GenerateCalendarAsync(request);
+
+        Assert.Contains("Deadlift: 5x5 @ 100kg", result.IcsContent);
+    }
+
+    [Fact]
+    public async Task SaveCalendarAsync_EmptyContent_ReturnsFailure()
+    {
+        var request = new SaveCalendarRequestDataTransferObject
+        {
+            IcsContent = string.Empty,
+            WorkoutName = "Test",
+        };
+
+        var service = this.CreateService();
+        var result = await service.SaveCalendarAsync(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.FilePath);
+    }
+
+    [Fact]
+    public async Task GenerateCalendarAsync_ContainsVCalendarEnvelope()
+    {
+        var template = new WorkoutTemplate
+        {
+            WorkoutTemplateId = 1,
+            Name = "Test",
+            Exercises = new List<TemplateExercise>(),
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetByIdAsync(1))
+            .ReturnsAsync(template);
+
+        var request = new GenerateCalendarRequestDataTransferObject
+        {
+            WorkoutTemplateId = 1,
+            DurationWeeks = 1,
+            SelectedDays = new List<DayOfWeek> { DayOfWeek.Monday },
+            StartDate = new DateTime(2026, 5, 5),
+        };
+
+        var service = this.CreateService();
+        var result = await service.GenerateCalendarAsync(request);
+
+        Assert.Contains("BEGIN:VCALENDAR", result.IcsContent);
+        Assert.Contains("END:VCALENDAR", result.IcsContent);
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int position = 0;
+        while ((position = text.IndexOf(pattern, position, StringComparison.Ordinal)) != -1)
+        {
+            position += pattern.Length;
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/Tests/CalendarWorkoutCatalogServiceTests.cs
+++ b/Tests/CalendarWorkoutCatalogServiceTests.cs
@@ -1,0 +1,87 @@
+using ClassLibrary.IRepositories;
+using ClassLibrary.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using WebAPI.Services;
+
+namespace Tests;
+
+public sealed class CalendarWorkoutCatalogServiceTests
+{
+    private const int ClientId = 7;
+
+    private readonly Mock<IWorkoutTemplateRepository> templateRepo = new();
+    private readonly Mock<ILogger<CalendarWorkoutCatalogService>> logger = new();
+
+    private CalendarWorkoutCatalogService CreateService() => new(this.templateRepo.Object, this.logger.Object);
+
+    [Fact]
+    public async Task GetAvailableWorkoutsAsync_RepositoryReturnsWorkouts_ReturnsMappedDtos()
+    {
+        var templates = new List<WorkoutTemplate>
+        {
+            new()
+            {
+                WorkoutTemplateId = 1,
+                Client = new Client { ClientId = ClientId },
+                Name = "Push Day",
+                Exercises = new List<TemplateExercise>(),
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetAvailableWorkoutsAsync(ClientId))
+            .ReturnsAsync(templates);
+
+        var service = this.CreateService();
+        var result = await service.GetAvailableWorkoutsAsync(ClientId, TimeSpan.FromSeconds(5));
+
+        Assert.Single(result.Workouts);
+        Assert.Equal("Push Day", result.Workouts[0].Name);
+    }
+
+    [Fact]
+    public async Task GetAvailableWorkoutsAsync_RepositoryThrows_ReturnsFallbackWorkouts()
+    {
+        this.templateRepo
+            .Setup(r => r.GetAvailableWorkoutsAsync(ClientId))
+            .ThrowsAsync(new InvalidOperationException("db error"));
+
+        var service = this.CreateService();
+        var result = await service.GetAvailableWorkoutsAsync(ClientId, TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, result.Workouts.Count);
+        Assert.All(result.Workouts, w => Assert.Equal("PREBUILT", w.Type));
+    }
+
+    [Fact]
+    public void GetFallbackWorkouts_ReturnsFallbackWithExercises()
+    {
+        var service = this.CreateService();
+        var result = service.GetFallbackWorkouts(ClientId);
+
+        Assert.Equal(2, result.Workouts.Count);
+        Assert.All(result.Workouts, w =>
+        {
+            Assert.Equal("PREBUILT", w.Type);
+            Assert.Equal(3, w.Exercises.Count);
+        });
+    }
+
+    [Fact]
+    public async Task GetAvailableWorkoutsAsync_Timeout_ReturnsFallbackWorkouts()
+    {
+        this.templateRepo
+            .Setup(r => r.GetAvailableWorkoutsAsync(ClientId))
+            .Returns(async () =>
+            {
+                await Task.Delay(5000);
+                return new List<WorkoutTemplate>();
+            });
+
+        var service = this.CreateService();
+        var result = await service.GetAvailableWorkoutsAsync(ClientId, TimeSpan.FromMilliseconds(50));
+
+        Assert.Equal(2, result.Workouts.Count);
+    }
+}

--- a/Tests/CalendarWorkoutCatalogServiceTests.cs
+++ b/Tests/CalendarWorkoutCatalogServiceTests.cs
@@ -71,17 +71,64 @@ public sealed class CalendarWorkoutCatalogServiceTests
     [Fact]
     public async Task GetAvailableWorkoutsAsync_Timeout_ReturnsFallbackWorkouts()
     {
+        // use a TaskCompletionSource so the "slow" repo never completes on its own —
+        // avoids flaky 5-second Task.Delay racing against a 50ms timeout
+        var neverCompletes = new TaskCompletionSource<IReadOnlyList<WorkoutTemplate>>();
+
         this.templateRepo
             .Setup(r => r.GetAvailableWorkoutsAsync(ClientId))
-            .Returns(async () =>
-            {
-                await Task.Delay(5000);
-                return new List<WorkoutTemplate>();
-            });
+            .Returns(neverCompletes.Task);
 
         var service = this.CreateService();
         var result = await service.GetAvailableWorkoutsAsync(ClientId, TimeSpan.FromMilliseconds(50));
 
         Assert.Equal(2, result.Workouts.Count);
+        Assert.All(result.Workouts, w => Assert.Equal("PREBUILT", w.Type));
+    }
+
+    [Fact]
+    public async Task GetAvailableWorkoutsAsync_maps_exercise_details_correctly()
+    {
+        var templates = new List<WorkoutTemplate>
+        {
+            new()
+            {
+                WorkoutTemplateId = 1,
+                Client = new Client { ClientId = ClientId },
+                Name = "Leg Day",
+                Exercises = new List<TemplateExercise>
+                {
+                    new() { Name = "Squat", TargetSets = 5, TargetReps = 5, TargetWeight = 100, MuscleGroup = MuscleGroup.LEGS },
+                    new() { Name = "Leg Press", TargetSets = 4, TargetReps = 8, TargetWeight = 180, MuscleGroup = MuscleGroup.LEGS },
+                },
+            },
+        };
+
+        this.templateRepo
+            .Setup(r => r.GetAvailableWorkoutsAsync(ClientId))
+            .ReturnsAsync(templates);
+
+        var service = this.CreateService();
+        var result = await service.GetAvailableWorkoutsAsync(ClientId, TimeSpan.FromSeconds(5));
+
+        var dto = result.Workouts[0];
+        Assert.Equal(2, dto.Exercises.Count);
+        Assert.Equal("Squat", dto.Exercises[0].Name);
+        Assert.Equal(5, dto.Exercises[0].TargetSets);
+        Assert.Equal(100, dto.Exercises[0].TargetWeight);
+    }
+
+    [Fact]
+    public void FallbackWorkouts_each_have_three_exercises()
+    {
+        var service = this.CreateService();
+        var result = service.GetFallbackWorkouts(ClientId);
+
+        Assert.All(result.Workouts, w =>
+        {
+            Assert.NotEmpty(w.Name);
+            Assert.Equal(3, w.Exercises.Count);
+            Assert.All(w.Exercises, e => Assert.True(e.TargetSets > 0));
+        });
     }
 }

--- a/Tests/NavigationServiceTests.cs
+++ b/Tests/NavigationServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.UI.Xaml.Controls;
 using Moq;
 using WinUI.Services;
 
@@ -27,5 +28,46 @@ public sealed class NavigationServiceTests
         service.NavigateToClientDashboard(false);
 
         this.refreshBus.Verify(b => b.RequestRefresh(), Times.Never);
+    }
+
+    [Fact]
+    public void GoBack_without_attached_frame_does_not_throw()
+    {
+        // no AttachFrame call → internal frame is null → should be a no-op
+        var service = this.CreateService();
+
+        var ex = Record.Exception(() => service.GoBack());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void NavigateToCalendarIntegration_without_frame_is_safe()
+    {
+        var service = this.CreateService();
+
+        var ex = Record.Exception(() => service.NavigateToCalendarIntegration());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void NavigateToRankShowcase_without_frame_is_safe()
+    {
+        var service = this.CreateService();
+
+        var ex = Record.Exception(() => service.NavigateToRankShowcase());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void NavigateToActiveWorkout_without_frame_does_not_throw()
+    {
+        var service = this.CreateService();
+
+        var ex = Record.Exception(() => service.NavigateToActiveWorkout(42));
+
+        Assert.Null(ex);
     }
 }

--- a/Tests/NavigationServiceTests.cs
+++ b/Tests/NavigationServiceTests.cs
@@ -1,0 +1,31 @@
+using Moq;
+using WinUI.Services;
+
+namespace Tests;
+
+public sealed class NavigationServiceTests
+{
+    private readonly Mock<IAnalyticsDashboardRefreshBus> refreshBus = new();
+
+    private NavigationService CreateService() => new(this.refreshBus.Object);
+
+    [Fact]
+    public void NavigateToClientDashboard_WithRefresh_CallsRequestRefresh()
+    {
+        var service = this.CreateService();
+
+        service.NavigateToClientDashboard(true);
+
+        this.refreshBus.Verify(b => b.RequestRefresh(), Times.Once);
+    }
+
+    [Fact]
+    public void NavigateToClientDashboard_WithoutRefresh_DoesNotCallRequestRefresh()
+    {
+        var service = this.CreateService();
+
+        service.NavigateToClientDashboard(false);
+
+        this.refreshBus.Verify(b => b.RequestRefresh(), Times.Never);
+    }
+}


### PR DESCRIPTION
Ported the calendar and navigation test files from VibeCoders.

CalendarExportServiceTests (8 cases) covers the ICS generation flow -- template lookup, validation for invalid week counts and empty day selection, event count verification, exercise description formatting, and the save-with-empty-content edge case.

CalendarWorkoutCatalogServiceTests (4 tests) covers the timeout/fallback logic -- verifies that the service returns repo results when available, falls back to prebuilt workouts on timeout or exception, and that fallback workouts have the expected structure.

NavigationServiceTests (2 tests) just validates the refresh bus integration -- NavigateToClientDashboard(true) triggers a refresh, false does not.

All 14 tests green.

Closes #348
Closes #349
Closes #351